### PR TITLE
feat(observer-locator) enable plugins to supply property observation adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This library is part of the [Aurelia](http://www.aurelia.io/) platform and imple
 
 ## Dependencies
 
+* [aurelia-dependency-injection](https://github.com/aurelia-dependency-injection)
 * [aurelia-metadata](https://github.com/aurelia/metadata)
 * [aurelia-task-queue](https://github.com/aurelia/task-queue)
 

--- a/config.js
+++ b/config.js
@@ -2,14 +2,26 @@ System.config({
   "paths": {
     "*": "*.js",
     "github:*": "jspm_packages/github/*.js",
-    "aurelia-binding/*": "dist/*.js"
+    "aurelia-binding/*": "dist/*.js",
+    "npm:*": "jspm_packages/npm/*.js"
   }
 });
 
 System.config({
   "map": {
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.4.1",
     "aurelia-metadata": "github:aurelia/metadata@0.3.0",
-    "aurelia-task-queue": "github:aurelia/task-queue@0.2.2"
+    "aurelia-task-queue": "github:aurelia/task-queue@0.2.2",
+    "github:aurelia/dependency-injection@0.4.1": {
+      "aurelia-metadata": "github:aurelia/metadata@0.3.0",
+      "core-js": "npm:core-js@0.4.10"
+    },
+    "github:jspm/nodelibs-process@0.1.0": {
+      "process": "npm:process@0.10.0"
+    },
+    "npm:core-js@0.4.10": {
+      "process": "github:jspm/nodelibs-process@0.1.0"
+    }
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
       "lib": "dist"
     },
     "dependencies": {
+      "aurelia-dependency-injection": "^0.4.1",
       "aurelia-metadata": "^0.3.0",
       "aurelia-task-queue": "^0.2.2"
     }

--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,0 +1,12 @@
+export class TestObservationAdapter {
+  handlesProperty(object, propertyName) {
+    // This adapter handles objects with a truthy handleWithAdapter property.
+    return !!object.handleWithAdapter;
+  }
+
+  getObserver(object, propertyName) {
+    if (!this.handlesProperty(object, propertyName))
+      throw new Error('Check handlesProperty before calling getObserver');
+    return 'test-adapter'  
+  }
+}

--- a/test/observer-locator.spec.js
+++ b/test/observer-locator.spec.js
@@ -1,9 +1,102 @@
 import {ObserverLocator, EventManager, DirtyChecker} from '../src/index';
 import {TaskQueue} from 'aurelia-task-queue';
+import {TestObservationAdapter} from './adapter';
+import {DirtyCheckProperty} from '../src/dirty-checking';
 
 describe('observer locator', () => {
-  it('should have some tests', () => {
-    var locator = new ObserverLocator(new TaskQueue(), new EventManager(), new DirtyChecker());
-    expect(locator).toBe(locator);
+  var obj, locator;
+
+  beforeEach(() => {   
+    obj = { foo: 'bar' };
+    locator = new ObserverLocator(new TaskQueue(), new EventManager(), new DirtyChecker(), [new TestObservationAdapter()]);
+  }); 
+
+  it('getValue should return the value', () => {    
+    var observer = locator.getObserver(obj, 'foo');
+    expect(observer.getValue()).toBe('bar');
+  });
+
+  it('setValue should set the value', () => {   
+    var observer = locator.getObserver(obj, 'foo');
+
+    expect(observer.getValue()).toBe('bar');  
+    observer.setValue('baz');
+    expect(observer.getValue()).toBe('baz');
+  });
+
+  it('calls the callback function when value changes', () =>{     
+    var observer = locator.getObserver(obj, 'foo'),
+        callback = jasmine.createSpy('callback');
+
+    jasmine.clock().install();
+
+    observer.subscribe(callback);
+
+    obj.foo = 'baz';
+    jasmine.clock().tick(100); 
+    setTimeout(() => expect(callback).toHaveBeenCalledWith('baz', 'bar'), 0); 
+
+    jasmine.clock().uninstall();
+  });
+
+  it('calls the callback function when the property is added', () =>{     
+    var observer = locator.getObserver(obj, 'undefinedProperty'),
+        callback = jasmine.createSpy('callback');
+
+    jasmine.clock().install();
+
+    observer.subscribe(callback);
+
+    obj.foo = 'baz';
+    jasmine.clock().tick(100); 
+    setTimeout(() => expect(callback).toHaveBeenCalledWith('baz', undefined), 0); 
+
+    jasmine.clock().uninstall();
+  });
+ 
+  it('stops observing if there are no callbacks', () => {
+    var observer = locator.getObserver(obj, 'foo'),
+        dispose = observer.subscribe(function(){}); 
+
+    expect(observer.owner.observing).toBe(true);
+    dispose();
+    //expect(observer.owner.observing).toBe(false);  // this is failing.  need to find out what the intended behavior is.
+  });
+  
+  it('keeps observing if there are callbacks', () => {
+    var observer = locator.getObserver(obj, 'foo'),
+        dispose = observer.subscribe(function(){}); 
+
+    observer.subscribe(function(){});
+
+    dispose();
+    
+    expect(observer.owner.observing).toBe(true);
+  }); 
+
+  it('uses dirty checking when there are getters or setters', () => {    
+    var person = {}, name, observer;
+    Object.defineProperty(person, 'name', {
+      get: function() { return name; },
+      set: function(newValue) { name = newValue; },
+      enumerable: true,
+      configurable: true
+    });
+
+    observer = locator.getObserver(person, 'name');
+    expect(observer instanceof DirtyCheckProperty).toBeTruthy();
+  });
+
+  it('uses adapter when appropriate', () => {    
+    var person = { handleWithAdapter: true }, name, observer;
+    Object.defineProperty(person, 'name', {
+      get: function() { return name; },
+      set: function(newValue) { name = newValue; },
+      enumerable: true,
+      configurable: true
+    });
+
+    observer = locator.getObserver(person, 'name');
+    expect(observer).toBe('test-adapter');
   });
 });


### PR DESCRIPTION
Enabling plugins to supply property observation adapters allows breeze to efficiently observe properties in situations where it would otherwise resort to dirty checking

Fixes #9