### PR TITLE
fix(ast): correct (in)equality operators against null operands

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -497,6 +497,13 @@ export class Binary extends Expression {
 
     var right = this.right.evaluate(scope);
 
+    switch (this.operation) {
+      case '==' : return left == right;
+      case '===': return left === right;
+      case '!=' : return left != right;
+      case '!==': return left !== right;
+    }
+
     // Null check for the operations.
     if (left === null || right === null) {
       switch (this.operation) {
@@ -519,10 +526,6 @@ export class Binary extends Expression {
       case '*'  : return left * right;
       case '/'  : return left / right;
       case '%'  : return left % right;
-      case '==' : return left == right;
-      case '===': return left === right;
-      case '!=' : return left != right;
-      case '!==': return left !== right;
       case '<'  : return left < right;
       case '>'  : return left > right;
       case '<=' : return left <= right;


### PR DESCRIPTION
Evaluate equality operator before null check. Currently, comparison with null doesn't work as expected and always evaluates to null.

For example, the following element will never be shown:
```html
<div if.bind="someValue == null">...</div>
```