### PR TITLE
fix(array-change-records): set addedCount to 0 on delete

### DIFF
--- a/src/array-change-records.js
+++ b/src/array-change-records.js
@@ -369,7 +369,7 @@ function createInitialSplices(array, changeRecords) {
         var index = toNumber(record.name);
         if (index < 0)
           continue;
-        mergeSplice(splices, index, [record.oldValue], 1);
+        mergeSplice(splices, index, [record.oldValue], 0);
         break;
       default:
         console.error('Unexpected record type: ' + JSON.stringify(record));


### PR DESCRIPTION
addedCount was set to 1 on delete which caused an empty viewSlot to be added after removal