### PR TITLE
fix(observer-locator) ObserverLocator assumes OoPropertyObserver when property is undefined

### DIFF
--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -69,8 +69,8 @@ function createObserversLookup(obj) {
   return value;
 }
 
-function createObserverLookup(obj) {
-  var value = new OoObjectObserver(obj);
+function createObserverLookup(obj, observerLocator) {
+  var value = new OoObjectObserver(obj, observerLocator);
 
   try{
     Object.defineProperty(obj, "__observer__", {
@@ -140,8 +140,8 @@ export class ObserverLocator {
     }
 
     if(hasObjectObserve){
-      observerLookup = obj.__observer__ || createObserverLookup(obj);
-      return observerLookup.getObserver(propertyName);
+      observerLookup = obj.__observer__ || createObserverLookup(obj, this);
+      return observerLookup.getObserver(propertyName, descriptor);
     }
 
     if(obj instanceof Array){

--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -83,9 +83,10 @@ export class SetterObserver {
 }
 
 export class OoObjectObserver {
-  constructor(obj){
+  constructor(obj, observerLocator){
     this.obj = obj;
     this.observers = {};
+    this.observerLocator = observerLocator;
   }
 
   subscribe(propertyObserver, callback){
@@ -104,10 +105,15 @@ export class OoObjectObserver {
     };
   }
 
-  getObserver(propertyName){
-    var propertyObserver = this.observers[propertyName]
-      || (this.observers[propertyName] = new OoPropertyObserver(this, this.obj, propertyName));
-
+  getObserver(propertyName, descriptor){
+    var propertyObserver = this.observers[propertyName];
+    if (!propertyObserver) {
+      if (descriptor) {
+        propertyObserver = this.observers[propertyName] = new OoPropertyObserver(this, this.obj, propertyName);
+      } else {
+        propertyObserver = this.observers[propertyName] = new UndefinedPropertyObserver(this, this.obj, propertyName);
+      }
+    }
     return propertyObserver;
   }
 
@@ -163,6 +169,106 @@ export class OoPropertyObserver {
 
   subscribe(callback){
     return this.owner.subscribe(this, callback);
+  }
+}
+
+export class UndefinedPropertyObserver {
+  constructor(owner, obj, propertyName){
+    this.owner = owner;
+    this.obj = obj;
+    this.propertyName = propertyName;
+    this.callbackMap = new Map();
+    this.callbacks = []; // unused here, but required by owner OoObjectObserver.
+    this.isSVG = obj instanceof SVGElement;
+  }
+
+  getValue(){
+    // delegate this to the actual observer if possible.
+    if (this.actual){
+      return this.actual.getValue();
+    }
+    return this.obj[this.propertyName];
+  }
+
+  setValue(newValue){
+    // delegate this to the actual observer if possible.
+    if (this.actual){
+      this.actual.setValue(newValue);
+      return;
+    }
+    // define the property and trigger the callbacks.
+    if(this.isSVG){
+      this.obj.setAttributeNS(null, this.propertyName, newValue);
+    }else{
+      this.obj[this.propertyName] = newValue;
+    }
+    this.trigger(newValue, undefined);
+  }
+
+  trigger(newValue, oldValue){
+    var callback;
+
+    // we only care about this event one time:  when the property becomes defined.
+    if (this.subscription){
+      this.subscription();
+    }
+
+    // get the actual observer.
+    this.getObserver();
+
+    // invoke the callbacks.
+    for(callback of this.callbackMap.keys()) {
+      callback(newValue, oldValue);
+    }
+  }
+
+  getObserver() {
+    var callback, observerLocator;
+
+    // has the property has been defined?
+    if (!Object.getOwnPropertyDescriptor(this.obj, this.propertyName)) {
+      return;
+    }
+
+    // get the actual observer.
+    observerLocator = this.owner.observerLocator;
+    delete this.owner.observers[this.propertyName];
+    delete observerLocator.getObserversLookup(this.obj, observerLocator)[this.propertyName];
+    this.actual = observerLocator.getObserver(this.obj, this.propertyName);
+
+    // attach any existing callbacks to the actual observer.
+    for(callback of this.callbackMap.keys()) {
+      this.callbackMap.set(callback, this.actual.subscribe(callback));
+    }
+  }
+
+  subscribe(callback){
+    // attempt to get the actual observer in case the property has become
+    // defined since the ObserverLocator returned [this].
+    if (!this.actual) {
+      this.getObserver();
+    }
+
+    // if we have the actual observer, use it.
+    if (this.actual){
+      return this.actual.subscribe(callback);
+    }
+
+    // start listening for the property to become defined.
+    if (!this.subscription){
+      this.subscription = this.owner.subscribe(this);
+    }
+
+    // cache the callback.
+    this.callbackMap.set(callback, null);
+
+    // return the method to dispose the subscription.
+    return () => {
+      var actualDispose = this.callbackMap.get(callback);
+      if (actualDispose)
+        actualDispose();
+      this.callbackMap.delete(callback);
+    };
   }
 }
 

--- a/test/observer-locator.spec.js
+++ b/test/observer-locator.spec.js
@@ -2,79 +2,116 @@ import {ObserverLocator, EventManager, DirtyChecker} from '../src/index';
 import {TaskQueue} from 'aurelia-task-queue';
 import {TestObservationAdapter} from './adapter';
 import {DirtyCheckProperty} from '../src/dirty-checking';
+import {OoPropertyObserver, UndefinedPropertyObserver} from '../src/property-observation';
 
 describe('observer locator', () => {
   var obj, locator;
 
-  beforeEach(() => {   
+  beforeEach(() => {
     obj = { foo: 'bar' };
     locator = new ObserverLocator(new TaskQueue(), new EventManager(), new DirtyChecker(), [new TestObservationAdapter()]);
-  }); 
+  });
 
-  it('getValue should return the value', () => {    
+  it('getValue should return the value', () => {
     var observer = locator.getObserver(obj, 'foo');
     expect(observer.getValue()).toBe('bar');
   });
 
-  it('setValue should set the value', () => {   
+  it('setValue should set the value', () => {
     var observer = locator.getObserver(obj, 'foo');
 
-    expect(observer.getValue()).toBe('bar');  
+    expect(observer.getValue()).toBe('bar');
     observer.setValue('baz');
     expect(observer.getValue()).toBe('baz');
   });
 
-  it('calls the callback function when value changes', () =>{     
+  it('calls the callback function when value changes', (done) =>{
     var observer = locator.getObserver(obj, 'foo'),
         callback = jasmine.createSpy('callback');
 
-    jasmine.clock().install();
-
     observer.subscribe(callback);
 
     obj.foo = 'baz';
-    jasmine.clock().tick(100); 
-    setTimeout(() => expect(callback).toHaveBeenCalledWith('baz', 'bar'), 0); 
-
-    jasmine.clock().uninstall();
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledWith('baz', 'bar');
+      done();
+    }, 0);
   });
 
-  it('calls the callback function when the property is added', () =>{     
+  it('uses OoPropertyObserver when a primitive property is added', (done) =>{
     var observer = locator.getObserver(obj, 'undefinedProperty'),
-        callback = jasmine.createSpy('callback');
+        callback = jasmine.createSpy('callback'),
+        unsubcribe;
 
-    jasmine.clock().install();
+    expect(locator.getObserver(obj, 'undefinedProperty') instanceof UndefinedPropertyObserver).toBe(true);
 
-    observer.subscribe(callback);
+    unsubcribe = observer.subscribe(callback);
 
-    obj.foo = 'baz';
-    jasmine.clock().tick(100); 
-    setTimeout(() => expect(callback).toHaveBeenCalledWith('baz', undefined), 0); 
+    obj.undefinedProperty = 'baz';
 
-    jasmine.clock().uninstall();
+    setTimeout(() => {
+      // inner observer should be an OoPropertyObserver
+      expect(observer.actual instanceof OoPropertyObserver).toBe(true);
+      // subsequent calls should return a OoPropertyObserver
+      expect(locator.getObserver(obj, 'undefinedProperty') instanceof OoPropertyObserver).toBe(true);
+
+      expect(callback).toHaveBeenCalledWith('baz', undefined);
+      unsubcribe();
+
+      done();
+    }, 0);
   });
- 
+
+  it('uses DirtyChecking when a complex property is added', (done) =>{
+    var observer = locator.getObserver(obj, 'undefinedProperty'),
+        callback = jasmine.createSpy('callback'),
+        innerValue,
+        unsubcribe;
+
+    expect(locator.getObserver(obj, 'undefinedProperty') instanceof UndefinedPropertyObserver).toBe(true);
+
+    unsubcribe = observer.subscribe(callback);
+
+    Object.defineProperty(obj, 'undefinedProperty', {
+      get: () => innerValue,
+      set: value => { innerValue = value; }
+    });
+    obj.undefinedProperty = 'baz';
+
+    setTimeout(() => {
+      // inner observer should be a DirtyCheckProperty
+      expect(observer.actual instanceof DirtyCheckProperty).toBe(true);
+      // subsequent calls should return a DirtyCheckProperty
+      expect(locator.getObserver(obj, 'undefinedProperty') instanceof DirtyCheckProperty).toBe(true);
+
+      expect(callback).toHaveBeenCalledWith('baz', undefined);
+      unsubcribe();
+
+      done();
+    }, 0);
+  });
+
   it('stops observing if there are no callbacks', () => {
     var observer = locator.getObserver(obj, 'foo'),
-        dispose = observer.subscribe(function(){}); 
+        dispose = observer.subscribe(function(){});
 
     expect(observer.owner.observing).toBe(true);
     dispose();
     //expect(observer.owner.observing).toBe(false);  // this is failing.  need to find out what the intended behavior is.
   });
-  
+
   it('keeps observing if there are callbacks', () => {
     var observer = locator.getObserver(obj, 'foo'),
-        dispose = observer.subscribe(function(){}); 
+        dispose = observer.subscribe(function(){});
 
     observer.subscribe(function(){});
 
     dispose();
-    
-    expect(observer.owner.observing).toBe(true);
-  }); 
 
-  it('uses dirty checking when there are getters or setters', () => {    
+    expect(observer.owner.observing).toBe(true);
+  });
+
+  it('uses dirty checking when there are getters or setters', () => {
     var person = {}, name, observer;
     Object.defineProperty(person, 'name', {
       get: function() { return name; },
@@ -87,7 +124,7 @@ describe('observer locator', () => {
     expect(observer instanceof DirtyCheckProperty).toBeTruthy();
   });
 
-  it('uses adapter when appropriate', () => {    
+  it('uses adapter when appropriate', () => {
     var person = { handleWithAdapter: true }, name, observer;
     Object.defineProperty(person, 'name', {
       get: function() { return name; },


### PR DESCRIPTION
Added UndefinedPropertyObserver, to be used when the property does not exist.

Fixes #23