### PR TITLE
fix(listener-expression): use result of event handler for preventDefault behavior

### DIFF
--- a/src/listener-expression.js
+++ b/src/listener-expression.js
@@ -45,7 +45,7 @@ class Listener {
       source.$event = event;
       var result = this.sourceExpression.evaluate(source);
       source.$event = prevEvent;
-      if(this.preventDefault){
+      if(result !== && this.preventDefault){
         event.preventDefault();
       }
       return result;

--- a/src/listener-expression.js
+++ b/src/listener-expression.js
@@ -45,7 +45,7 @@ class Listener {
       source.$event = event;
       var result = this.sourceExpression.evaluate(source);
       source.$event = prevEvent;
-      if(result !== && this.preventDefault){
+      if(result !== true && this.preventDefault){
         event.preventDefault();
       }
       return result;


### PR DESCRIPTION
Before, all events were `defaultPrevented` by default. Now, if the result of a callback is exactly true, `event.preventDefault()` is NOT called.

closes #16