### PR TITLE
collection-observation base class

### DIFF
--- a/src/array-change-records.js
+++ b/src/array-change-records.js
@@ -369,7 +369,7 @@ function createInitialSplices(array, changeRecords) {
         var index = toNumber(record.name);
         if (index < 0)
           continue;
-        mergeSplice(splices, index, [record.oldValue], 0);
+        mergeSplice(splices, index, [record.oldValue], record.type === 'delete' ? 0 : 1);
         break;
       default:
         console.error('Unexpected record type: ' + JSON.stringify(record));

--- a/src/collection-observation.js
+++ b/src/collection-observation.js
@@ -1,0 +1,131 @@
+import {calcSplices, projectArraySplices} from './array-change-records';
+
+export class ModifyCollectionObserver {
+
+  constructor(taskQueue, collection){
+    this.taskQueue = taskQueue;
+    this.queued = false;
+    this.callbacks = [];
+    this.changeRecords = [];
+    this.oldCollection = null;
+    this.collection = collection;
+    this.lengthPropertyName = collection instanceof Map ? 'size' : 'length';
+  }
+    
+  subscribe(callback){
+    var callbacks = this.callbacks;
+    callbacks.push(callback);
+    return function(){
+      callbacks.splice(callbacks.indexOf(callback), 1);
+    };
+  }
+
+  addChangeRecord(changeRecord){
+    if(this.callbacks.length === 0){
+      return;
+    }
+
+    this.changeRecords.push(changeRecord);
+
+    if(!this.queued){
+      this.queued = true;
+      this.taskQueue.queueMicroTask(this);
+    }
+  }
+
+  reset(oldCollection){
+    if(!this.callbacks.length){
+      return;
+    }
+
+    this.oldCollection = oldCollection;
+
+    if(!this.queued){
+      this.queued = true;
+      this.taskQueue.queueMicroTask(this);
+    }
+  }
+
+  getObserver(propertyName){
+    if(propertyName == this.lengthPropertyName){
+      return this.lengthObserver || (this.lengthObserver = new CollectionLengthObserver(this.collection, this.lengthPropertyName));
+    }else{
+      throw new Error(`You cannot observe the ${propertyName} property of an array.`);
+    }
+  }
+
+  call(){
+    var callbacks = this.callbacks,
+      i = callbacks.length,
+      changeRecords = this.changeRecords,
+      oldCollection = this.oldCollection,
+      records;
+
+    this.queued = false;
+    this.changeRecords = [];
+    this.oldCollection = null;
+
+    if(i){
+      if(oldCollection){
+        // TODO (martingust) we might want to refactor this to a common, independent of collection type, way of getting the records
+        if(this.collection instanceof Map){
+          records = getChangeRecords(oldCollection);
+        }else {
+          //we might need to combine this with existing change records....
+          records = calcSplices(this.collection, 0, this.collection.length, oldCollection, 0, oldCollection.length);
+        }
+      }else{
+        if(this.collection instanceof Map){
+          records = changeRecords;
+        }else {
+          records = projectArraySplices(this.collection, changeRecords);
+        }
+      }
+
+      while(i--) {
+        callbacks[i](records);
+      }
+    }
+
+    if(this.lengthObserver){
+      this.lengthObserver(this.array.length);
+    }
+  }
+}
+
+export class CollectionLengthObserver {
+  constructor(collection){
+    this.collection = collection;
+    this.callbacks = [];
+    this.lengthPropertyName = collection instanceof Map ? 'size' : 'length';
+    this.currentValue = collection[this.lengthPropertyName];
+  }
+
+  getValue(){
+    return this.collection[this.lengthPropertyName];
+  }
+
+  setValue(newValue){
+    this.collection[this.lengthPropertyName] = newValue;
+  }
+
+  subscribe(callback){
+    var callbacks = this.callbacks;
+    callbacks.push(callback);
+    return function(){
+      callbacks.splice(callbacks.indexOf(callback), 1);
+    };
+  }
+
+  call(newValue){
+    var callbacks = this.callbacks,
+      i = callbacks.length,
+      oldValue = this.currentValue;
+
+    while(i--) {
+      callbacks[i](newValue, oldValue);
+    }
+
+    this.currentValue = newValue;
+  }
+}

--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -13,7 +13,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
   }
 
   static create(taskQueue, map) {
-    var observer = new ModifyCollectionObserver(taskQueue, map);
+    var observer = new ModifyMapObserver(taskQueue, map);
 
     map['set'] = function () {
       var oldValue = map.get(arguments[0]);

--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -1,4 +1,5 @@
 import {getEntries, getChangeRecords} from './map-change-records';
+import {ModifyCollectionObserver} from './collection-observation';
 
 var mapProto = Map.prototype;
 
@@ -6,87 +7,13 @@ export function getMapObserver(taskQueue, map){
   return ModifyMapObserver.create(taskQueue, map);
 }
 
-class ModifyMapObserver {
+class ModifyMapObserver extends ModifyCollectionObserver {
   constructor(taskQueue, map){
-    this.taskQueue = taskQueue;
-    this.callbacks = [];
-    this.changeRecords = [];
-    this.queued = false;
-    this.map = map;
-    this.oldMap = null;
-  }
-
-  subscribe(callback){
-    var callbacks = this.callbacks;
-    callbacks.push(callback);
-    return function(){
-      callbacks.splice(callbacks.indexOf(callback), 1);
-    };
-  }
-
-  addChangeRecord(changeRecord){
-    if(this.callbacks.length === 0){
-      return;
-    }
-
-    this.changeRecords.push(changeRecord);
-
-    if(!this.queued){
-      this.queued = true;
-      this.taskQueue.queueMicroTask(this);
-    }
-  }
-
-  reset(){
-    if(!this.callbacks.length){
-      return;
-    }
-
-    this.oldMap = this.map;
-
-    if(!this.queued){
-      this.queued = true;
-      this.taskQueue.queueMicroTask(this);
-    }
-  }
-
-  getObserver(propertyName){
-    if(propertyName == 'size'){
-      return this.lengthObserver || (this.lengthObserver = new MapLengthObserver(this.map));
-    }else{
-      throw new Error(`You cannot observe the ${propertyName} property of a map.`);
-    }
-  }
-
-  call(){
-    var callbacks = this.callbacks,
-      i = callbacks.length,
-      changeRecords = this.changeRecords,
-      oldMap = this.oldMap,
-      records;
-
-    this.queued = false;
-    this.changeRecords = [];
-
-    if (i) {
-      if (oldMap) {
-        records = getChangeRecords(oldMap);
-      }else{
-        records = changeRecords;
-      }
-
-      while (i--) {
-        callbacks[i](records);
-      }
-    }
-
-    if(this.lengthObserver){
-      this.lengthObserver(this.map.size);
-    }
+    super(taskQueue, map);
   }
 
   static create(taskQueue, map) {
-    var observer = new ModifyMapObserver(taskQueue, map);
+    var observer = new ModifyCollectionObserver(taskQueue, map);
 
     map['set'] = function () {
       var oldValue = map.get(arguments[0]);
@@ -123,41 +50,5 @@ class ModifyMapObserver {
     }
 
     return observer;
-  }
-}
-
-class MapLengthObserver {
-  constructor(map){
-    this.map = map;
-    this.callbacks = [];
-    this.currentValue = map.size;
-  }
-
-  getValue(){
-    return this.map.size;
-  }
-
-  setValue(newValue){
-    this.map.size = newValue;
-  }
-
-  subscribe(callback){
-    var callbacks = this.callbacks;
-    callbacks.push(callback);
-    return function(){
-      callbacks.splice(callbacks.indexOf(callback), 1);
-    };
-  }
-
-  call(newValue){
-    var callbacks = this.callbacks,
-      i = callbacks.length,
-      oldValue = this.currentValue;
-
-    while(i--) {
-      callbacks[i](newValue, oldValue);
-    }
-
-    this.currentValue = newValue;
   }
 }


### PR DESCRIPTION
I took a shot extracting base classes (collection-observation) for array-observation and map-observation. They contained a lot of duplicated code. Let me know if you see any issues or improvements. It's pretty scary to touch this before we get the unit tests in place.

My earlier fix (https://github.com/aurelia/binding/commit/fb6cbe9fd2574994787e2da43a5526f655ab21d2) for addedCount only fixed when delete. Update should still have addedCount 1. Fix for this should be included as well.