### PR TITLE
fix(SelectValueObserver) Safari and Internet Explorer

### DIFF
--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -411,21 +411,23 @@ export class SelectValueObserver {
   }
 
   synchronizeValue(){
-    var selectedOptions = this.element.selectedOptions,
-        count = selectedOptions.length,
-        option, i, value;
+    var options = this.element.options, option, i, ii, count = 0, value = [];
 
-    if (this.element.multiple) {
-      value = [];
-      for(i = 0; i < count; i++) {
-        option = selectedOptions.item(i);
-        value[i] = option.hasOwnProperty('model') ? option.model : option.value;
+    for(i = 0, ii = options.length; i < ii; i++) {
+      option = options.item(i);
+      if (!option.selected) {
+        continue;
       }
-    } else if (count === 0) {
-      value = null;
-    } else {
-      option = selectedOptions.item(0);
-      value = option.hasOwnProperty('model') ? option.model : option.value;
+      value[count] = option.hasOwnProperty('model') ? option.model : option.value;
+      count++;
+    }
+
+    if (!this.element.multiple) {
+      if (count === 0) {
+        value = null;
+      } else {
+        value = value[0];
+      }
     }
 
     this.oldValue = this.value;
@@ -479,34 +481,4 @@ export class SelectValueObserver {
       this.arraySubscription = null;
     }
   }
-}
-
-// polyfill HTMLSelectElement.selectedOptions
-class SelectedOptions {
-  constructor(element) {
-    var options = element.options, option, selected = [], i, ii;
-    for (i = 0, ii = options.length; i < ii; i++) {
-      option = options[i];
-      if (option.selected) {
-        selected.push(option);
-      }
-    }
-    this.selected = selected;
-    this.length = selected.length;
-  }
-
-  item(i) {
-    return this.selected[i];
-  }
-}
-
-if (!HTMLSelectElement.prototype.selectedOptions) {
-  Object.defineProperty(
-    HTMLSelectElement.prototype,
-    'selectedOptions',
-    {
-      get: function() {
-        return new SelectedOptions(this);
-      }
-    });
 }

--- a/test/binding-expression.spec.js
+++ b/test/binding-expression.spec.js
@@ -36,21 +36,23 @@ describe('select element value binding', () => {
   });
 
   function getElementValue(element) {
-    var selectedOptions = element.selectedOptions,
-        count = selectedOptions.length,
-        option, i, value;
+    var options = element.options, option, i, ii, count = 0, value = [];
 
-    if (element.multiple) {
-      value = [];
-      for(i = 0; i < count; i++) {
-        option = selectedOptions.item(i);
-        value[i] = option.hasOwnProperty('model') ? option.model : option.value;
+    for(i = 0, ii = options.length; i < ii; i++) {
+      option = options.item(i);
+      if (!option.selected) {
+        continue;
       }
-    } else if (count === 0) {
-      value = null;
-    } else {
-      option = selectedOptions.item(0);
-      value = option.hasOwnProperty('model') ? option.model : option.value;
+      value[count] = option.hasOwnProperty('model') ? option.model : option.value;
+      count++;
+    }
+
+    if (!element.multiple) {
+      if (count === 0) {
+        value = null;
+      } else {
+        value = value[0];
+      }
     }
     return value;
   }


### PR DESCRIPTION
Removed the `HTMLSelectElement.selectedItems` polyfill because it caused problems with Safari and only Internet Explorer needed it.  All tests passing and the integration tests work in Chrome, Firefox and IE.  Wasn't able to test Safari because of another issue is preventing the app from loading.  Here's the safari error at startup:

``` bash
[Error] SyntaxError: Cannot declare a parameter named 'fetch' as it shadows the name of a strict mode function.
    appendChild (skeleton-navigation, line 88)
    doEval (system.js, line 1)
    __eval (system.js, line 1)
    a (system.js, line 1)
    instantiate (system.js, line 1)
    instantiate (system.js, line 1)
    instantiate (system.js, line 1)
    instantiate (system.js, line 1)
    instantiate (system.js, line 1)
    instantiate (system.js, line 1)
    (anonymous function) (es6-module-loader.js, line 7)
    O (es6-module-loader.js, line 7)
    K (es6-module-loader.js, line 7)
    when (es6-module-loader.js, line 7)
    run (es6-module-loader.js, line 7)
    _drain (es6-module-loader.js, line 7)
    drain (es6-module-loader.js, line 7)
[Error] Potentially unhandled rejection [3] Error loading "github:aurelia/loader-default@0.4.3/index" at http://jdanyow.github.io/skeleton-navigation/jspm_packages/github/aurelia/loader-default@0.4.3/index.js
Error loading "github:aurelia/loader-default@0.4.3/index" from "github:aurelia/loader-default@0.4.3" at http://jdanyow.github.io/skeleton-navigation/jspm_packages/github/aurelia/loader-default@0.4.3.js
Error evaluating http://jdanyow.github.io/skeleton-navigation/jspm_packages/github/aurelia/loader-default@0.4.3/index.js
SyntaxError: Cannot declare a parameter named 'fetch' as it shadows the name of a strict mode function. (WARNING: non-Error used)
    (anonymous function) (es6-module-loader.js, line 7)
    f (es6-module-loader.js, line 7)
    i (es6-module-loader.js, line 7)
```