### PR TITLE
fix(AST): do not coerce operands of || or && to booleans

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -478,8 +478,8 @@ export class Binary extends Expression {
     var left = this.left.evaluate(scope);
 
     switch (this.operation) {
-      case '&&': return !!left && !!this.right.evaluate(scope);
-      case '||': return !!left || !!this.right.evaluate(scope);
+      case '&&': return left && this.right.evaluate(scope);
+      case '||': return left || this.right.evaluate(scope);
     }
 
     var right = this.right.evaluate(scope);


### PR DESCRIPTION
fixes aurelia/templating-binding#37