### PR TITLE
fix(binding): Use correct import for core-js

### DIFF
--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {getChangeRecords} from './map-change-records';
 import {ModifyCollectionObserver} from './collection-observation';
 

--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 export class SetterObserver {
   constructor(taskQueue, obj, propertyName){

--- a/src/value-converter.js
+++ b/src/value-converter.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 function camelCase(name){
   return name.charAt(0).toLowerCase() + name.slice(1);


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes https://github.com/aurelia/framework/issues/177