### PR TITLE
fix(ValueAttributeObserver): set undefined/null to empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "karma-coverage": "^0.3.1",
     "karma-ie-launcher": "^0.1.5",
     "karma-jasmine": "^0.3.5",
-    "karma-jspm": "^1.1.5",
+    "karma-jspm": "^2.0.1",
     "object.assign": "^1.0.3",
     "require-dir": "^0.1.0",
     "run-sequence": "^1.0.2",

--- a/src/binding-expression.js
+++ b/src/binding-expression.js
@@ -80,9 +80,7 @@ class Binding {
         });
       }
 
-      if(info.value !== undefined){
-        targetProperty.setValue(info.value);
-      }
+      targetProperty.setValue(info.value);
 
       if(this.mode == bindingMode.twoWay){
         this._disposeListener = targetProperty.subscribe(newValue => {
@@ -91,12 +89,9 @@ class Binding {
       }
 
       this.source = source;
-    }else{
+    } else {
       var value = this.sourceExpression.evaluate(source, this.valueConverterLookupFunction);
-
-      if(value !== undefined){
-        targetProperty.setValue(value);
-      }
+      targetProperty.setValue(value);
     }
   }
 

--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -85,7 +85,9 @@ export class ValueAttributeObserver {
   }
 
   setValue(newValue) {
-    this.element[this.propertyName] = newValue;
+    this.element[this.propertyName] =
+      (newValue === undefined || newValue === null) ? '' : newValue;
+
     this.call();
   }
 

--- a/test/access-keyed-observer.spec.js
+++ b/test/access-keyed-observer.spec.js
@@ -456,7 +456,7 @@ describe('AccessKeyedObserver', () => {
     it('responds to out of bounds key change', done => {
       obj.key = 99;
       setTimeout(() => {
-        expect(el.value).toBe('undefined');
+        expect(el.value).toBe('');
         obj.key = 1;
         done();
         }, checkDelay * 2);

--- a/test/element-observation.spec.js
+++ b/test/element-observation.spec.js
@@ -99,20 +99,26 @@ describe('element observation', () => {
   it('value attributes', (done) => {
     var cases = [
         { tag: '<input type="text" value="foo" />', attr: 'value', old: 'foo', new: 'bar' },
+        { tag: '<input type="text" value="foo" />', attr: 'value', old: 'foo', new: undefined, expected: '' },
+        { tag: '<input type="text" value="foo" />', attr: 'value', old: 'foo', new: null, expected: '' },
+
         { tag: '<textarea>foo</textarea>', attr: 'value', old: 'foo', new: 'bar' },
+        { tag: '<textarea>foo</textarea>', attr: 'value', old: 'foo', new: undefined, expected: '' },
+        { tag: '<textarea>foo</textarea>', attr: 'value', old: 'foo', new: null, expected: '' },
       ],
       remaining = cases.length;
     cases.forEach(test => {
       var el = createElement(test.tag),
           observer = locator.getObserver(el, test.attr),
           callback = jasmine.createSpy('callback'),
-          dispose = observer.subscribe(callback);
+          dispose = observer.subscribe(callback),
+          expected = test.hasOwnProperty('expected') ? test.expected : test.new;
       expect(observer instanceof ValueAttributeObserver).toBe(true);
       expect(observer.getValue()).toBe(test.old);
       observer.setValue(test.new);
-      expect(observer.getValue()).toBe(test.new);
+      expect(observer.getValue()).toBe(expected);
       setTimeout(() => {
-        expect(callback).toHaveBeenCalledWith(test.new, test.old);
+        expect(callback).toHaveBeenCalledWith(expected, test.old);
         dispose();
         remaining--;
         if (remaining === 0) {


### PR DESCRIPTION
Previously when passed a null or undefined value, a
ValueAttributeObserver would set the value of that html element to
a string representation of that value. This patch changes that
behavior to be more in line with the initial BindingExpression
behavior of setting that value to an empty string.