### PR TITLE
fix(ObserverLocator): enable adapter installation after instantiation

### DIFF
--- a/test/adapter.js
+++ b/test/adapter.js
@@ -1,31 +1,18 @@
 // An ObjectObservationAdapter for test purposes.
 // Delegates work to a real observer provided by the observer locator.
-// Adapter handles objects with a truthy "handleWithAdapter" property.
 export class TestObservationAdapter {
   constructor(locatorProvider) {
     this.locatorProvider = locatorProvider;
   }
 
-  handlesProperty(object, propertyName, descriptor) {
-    return !!object.handleWithAdapter;
-  }
-
   getObserver(object, propertyName, descriptor) {
-    var observer;
-    if (!this.handlesProperty(object, propertyName, descriptor))
-      throw new Error('Check handlesProperty before calling getObserver');
+    if (!object.handleWithAdapter) {
+      return null;
+    }
     object.handleWithAdapter = false;
-    observer = this.locatorProvider().getObserver(object, propertyName);
+    let observer = this.locatorProvider().getObserver(object, propertyName);
     object.handleWithAdapter = true;
-    return new AdapterPropertyObserver(observer)
-  }
-}
-
-export class AdapterPropertyObserver {
-  constructor(observer) {
-    this.getValue = () => observer.getValue();
-    this.setValue = newValue => observer.setValue(newValue);
-    this.subscribe = callback => observer.subscribe(callback);
-    this.unsubscribe = callback => observer.unsubscribe(callback);
+    observer.___from_adapter = true; // for unit-tests
+    return observer;
   }
 }

--- a/test/observer-locator.spec.js
+++ b/test/observer-locator.spec.js
@@ -1,4 +1,4 @@
-import {TestObservationAdapter, AdapterPropertyObserver} from './adapter';
+import {TestObservationAdapter} from './adapter';
 import {DirtyCheckProperty} from '../src/dirty-checking';
 import {
   OoPropertyObserver,
@@ -156,8 +156,7 @@ describe('ObserverLocator', () => {
   it('uses Adapter for for defined, complex properties on pojos that adapter canObserve', () => {
     var obj = { handleWithAdapter: true }, foo, observer, adapter, descriptor;
 
-    adapter = locator.observationAdapters[0];
-    spyOn(adapter, 'handlesProperty').and.callThrough();
+    adapter = locator.adapters[0];
     spyOn(adapter, 'getObserver').and.callThrough();
 
     Object.defineProperty(obj, 'foo', {
@@ -170,8 +169,7 @@ describe('ObserverLocator', () => {
     descriptor = Object.getOwnPropertyDescriptor(obj, 'foo');
 
     observer = locator.getObserver(obj, 'foo');
-    expect(observer instanceof AdapterPropertyObserver).toBe(true);
-    expect(adapter.handlesProperty).toHaveBeenCalledWith(obj, 'foo', descriptor);
+    expect(observer.___from_adapter).toBe(true);
     expect(adapter.getObserver).toHaveBeenCalledWith(obj, 'foo', descriptor);
   });
 });

--- a/test/shared.js
+++ b/test/shared.js
@@ -25,7 +25,8 @@ export function fireEvent(element, name) {
 }
 
 export function createObserverLocator(adapters = []) {
-  var locator = new ObserverLocator(new TaskQueue(), new EventManager(), new DirtyChecker(), adapters);
+  let locator = new ObserverLocator(new TaskQueue(), new EventManager(), new DirtyChecker());
+  adapters.forEach(a => locator.addAdapter(a));
   locator.dirtyChecker.checkDelay = checkDelay;
   return locator;
 }


### PR DESCRIPTION
This change also streamlines the ObjectObservationAdapter API, resulting in an easier to implement and more performant interface.

Fixes jdanyow/aurelia-computed#8