### PR TITLE
feat(BindingSystem): add binding system API

### DIFF
--- a/src/binding-system.js
+++ b/src/binding-system.js
@@ -1,0 +1,87 @@
+import {TaskQueue} from 'aurelia-task-queue';
+import {bindingMode} from './binding-mode';
+import {DirtyChecker} from './dirty-checking';
+import {EventManager} from './event-manager';
+import {ObserverLocator} from './observer-locator';
+import {Parser} from './parser';
+import {BindingExpression} from './binding-expression';
+
+let taskQueue;
+let eventManager;
+let dirtyChecker;
+let observerLocator;
+let parser;
+
+export let __initialized = false;
+
+function initialize(container = null) {
+  container = container || { get: () => null };
+  taskQueue = container.get(TaskQueue) || new TaskQueue();
+  eventManager = container.get(EventManager) || new EventManager();
+  dirtyChecker = container.get(DirtyChecker) || new DirtyChecker();
+  observerLocator = container.get(ObserverLocator) || new ObserverLocator(taskQueue, eventManager, dirtyChecker);
+  parser = container.get(Parser) || new Parser();
+  __initialized = true;
+}
+
+export function __uninitializeBindingSystem() {
+  taskQueue = null;
+  eventManager = null;
+  dirtyChecker = null;
+  observerLocator = null
+  parser = null;
+  __initialized = false;
+}
+
+function assertInitialized() {
+  if (!__initialized) {
+    initialize();
+  }
+}
+
+export const BindingSystem = {
+  initialize: initialize,
+
+  createBindingExpression(targetProperty, sourceExpression, mode = bindingMode.oneWay) {
+    assertInitialized();
+    return new BindingExpression(observerLocator, targetProperty, parser.parse(sourceExpression), mode);
+  },
+
+  observePropertyChanges(obj, propertyName, callback) {
+    assertInitialized();
+    let observer = observerLocator.getObserver(obj, propertyName);
+    observer.subscribe(callback);
+  },
+
+  unobservePropertyChanges(obj, propertyName, callback) {
+    assertInitialized();
+    let observer = observerLocator.getObserver(obj, propertyName);
+    observer.unsubscribe(callback);
+  },
+
+  observeCollectionChanges(collection, callback) {
+    assertInitialized();
+    let observer;
+    if (collection instanceof Array) {
+      observer = observerLocator.getArrayObserver(collection);
+    } else if (collection instanceof Map) {
+      observer = observerLocator.getMapObserver(collection);
+    } else {
+      throw new Error('collection must be an instance of Array or Map.');
+    }
+    observer.subscribe(callback);
+  },
+
+  unobserveCollectionChanges(collection, callback) {
+    assertInitialized();
+    let observer;
+    if (collection instanceof Array) {
+      observer = observerLocator.getArrayObserver(collection);
+    } else if (collection instanceof Map) {
+      observer = observerLocator.getMapObserver(collection);
+    } else {
+      throw new Error('collection must be an instance of Array or Map.');
+    }
+    observer.unsubscribe(callback);
+  }
+}

--- a/test/binding-system.spec.js
+++ b/test/binding-system.spec.js
@@ -1,0 +1,124 @@
+import {TaskQueue} from 'aurelia-task-queue';
+import {bindingMode} from '../src/binding-mode';
+import {DirtyChecker} from '../src/dirty-checking';
+import {EventManager} from '../src/event-manager';
+import {ObserverLocator} from '../src/observer-locator';
+import {Parser} from '../src/parser';
+import {BindingExpression} from '../src/binding-expression';
+import {BindingSystem, __uninitializeBindingSystem, __initialized} from '../src/binding-system';
+
+describe('BindingSystem', () => {
+  let mockContainer;
+
+  beforeAll(() => {
+    let taskQueue = new TaskQueue();
+    let eventManager = new EventManager();
+    let dirtyChecker = new DirtyChecker();
+    let observerLocator = new ObserverLocator(taskQueue, eventManager, dirtyChecker);
+    let parser = new Parser();
+
+    mockContainer = {
+      get: key => {
+        switch(key) {
+          case TaskQueue:
+            return taskQueue;
+          case EventManager:
+            return eventManager;
+          case DirtyChecker:
+            return dirtyChecker;
+          case ObserverLocator:
+            return observerLocator;
+          case Parser:
+            return parser;
+        }
+      }
+    }
+  });
+
+  it('initializes automatically', () => {
+    __uninitializeBindingSystem();
+    expect(__initialized).toBe(false);
+    BindingSystem.observePropertyChanges({ foo: 'bar' }, 'foo', () => {});
+    expect(__initialized).toBe(true);
+  });
+
+  it('initializes without container', () => {
+    __uninitializeBindingSystem();
+    expect(__initialized).toBe(false);
+    BindingSystem.initialize();
+    expect(__initialized).toBe(true);
+  });
+
+  it('initializes with container', () => {
+    __uninitializeBindingSystem();
+    expect(__initialized).toBe(false);
+    spyOn(mockContainer, 'get').and.callThrough();
+    BindingSystem.initialize(mockContainer);
+    expect(mockContainer.get).toHaveBeenCalled();
+    expect(__initialized).toBe(true);
+  });
+
+  it('observes and unobserves property changes', done => {
+    let obj = { foo: 'bar' };
+    let callback = jasmine.createSpy('callback');
+    BindingSystem.observePropertyChanges(obj, 'foo', callback);
+    obj.foo = 'baz';
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledWith('baz', 'bar');
+      BindingSystem.unobservePropertyChanges(obj, 'foo', callback);
+      callback.calls.reset();
+      obj.foo = 'test';
+      setTimeout(() => {
+        expect(callback).not.toHaveBeenCalled();
+        done();
+      })
+    });
+  });
+
+  it('observes and unobserves array changes', done => {
+    let obj = [];
+    let callback = jasmine.createSpy('callback');
+    BindingSystem.observeCollectionChanges(obj, callback);
+    obj.push('foo');
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalled();
+      BindingSystem.unobserveCollectionChanges(obj, callback);
+      callback.calls.reset();
+      obj.push('bar');
+      setTimeout(() => {
+        expect(callback).not.toHaveBeenCalled();
+        done();
+      })
+    });
+  });
+
+  it('observes and unobserves map changes', done => {
+    let obj = new Map();
+    let callback = jasmine.createSpy('callback');
+    BindingSystem.observeCollectionChanges(obj, callback);
+    obj.set('foo', 'bar');
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalled();
+      BindingSystem.unobserveCollectionChanges(obj, callback);
+      callback.calls.reset();
+      obj.set('foo', 'baz');
+      setTimeout(() => {
+        expect(callback).not.toHaveBeenCalled();
+        done();
+      })
+    });
+  });
+
+  it('gets BindingExpressions', () => {
+    let target = document.createElement('input');
+    let targetProperty = 'value';
+    let source = { foo: 'bar' };
+    let sourceExpression = 'foo';
+    let bindingExpression = BindingSystem.createBindingExpression(targetProperty, sourceExpression);
+    expect(bindingExpression instanceof BindingExpression).toBe(true);
+    let binding = bindingExpression.createBinding(target);
+    binding.bind(source);
+    expect(target.value).toBe('bar');
+    binding.unbind();
+  });
+});


### PR DESCRIPTION
@EisenbergEffect this is a work in progress.  Let me know what you think.

The current design would require us to add the following somewhere in aurelia framework:

```js
import {initializeBindingSystem} from 'aurelia-binding';

initializeBindingSystem(container);
```

To use this outside of an Aurelia application, `initializeBindingSystem()` would be required although we could refactor the BindingSystem class to make the static methods lazy initialize when they're called to support the external or unit-test scenarios more cleanly.

My thinking was this would preserve our ability to have one instance of services like the TaskQueue and EventManager in the container while still enabling external and unit-testing scenarios.

Remaining work:
* remove DI dependency in package.json
* fixup templating where there is a dep on the old BindingExpression.create API