### PR TITLE
Deleting last array element generates incorrect change record.

### DIFF
--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -65,7 +65,6 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
     };
 
     array['splice'] = function() {
-      var methodCallResult = arrayProto['splice'].apply(array, arguments);
       var index = arguments[0];
       if (index >= array.length && array.length > 0) {
         index = array.length - 1;
@@ -74,6 +73,7 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
       } else if (index < 0 ) {
         index = array.length + index - 1;
       }
+      var methodCallResult = arrayProto['splice'].apply(array, arguments);
       observer.addChangeRecord({
        type: 'splice',
        object: array,


### PR DESCRIPTION
Hello Guys, this is my first Pull Request so I hope you'll be lenient on me :-)

I found a bug whereby deleting the last item of an array results in a repeat.for view actually removing the second-last item not the last item. 

Kevin 