### PR TITLE
fix(ModifyCollectionObserver): handle out of bound splices

### DIFF
--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -66,18 +66,10 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
 
     array['splice'] = function() {
       var methodCallResult = arrayProto['splice'].apply(array, arguments);
-      var index = arguments[0];
-      if (index >= array.length && array.length > 0) {
-        index = array.length - 1;
-      } else if (-index >= array.length) {
-        index = 0;
-      } else if (index < 0 ) {
-        index = array.length + index - 1;
-      }
       observer.addChangeRecord({
        type: 'splice',
        object: array,
-       index: index,
+       index: arguments[0],
        removed: methodCallResult,
        addedCount: arguments.length > 2 ? arguments.length - 2 : 0
       });

--- a/src/collection-observation.js
+++ b/src/collection-observation.js
@@ -26,6 +26,20 @@ export class ModifyCollectionObserver {
       return;
     }
 
+    if (changeRecord.type === 'splice') {
+      var index = changeRecord.index;
+      var arrayLength = changeRecord.object.length;
+      if (index > arrayLength) {
+        index = arrayLength - changeRecord.addedCount;
+      } else if (index < 0) {
+        index = arrayLength + changeRecord.removed.length + index - changeRecord.addedCount;
+      }
+      if(index < 0){
+        index = 0;
+      }
+      changeRecord.index = index;
+    }
+
     if (this.changeRecords === null) {
       this.changeRecords = [changeRecord];
     } else {

--- a/test/collection-observeration.spec.js
+++ b/test/collection-observeration.spec.js
@@ -1,4 +1,5 @@
 import {createObserverLocator, checkDelay} from './shared';
+import {ModifyCollectionObserver} from '../src/collection-observation';
 import {initialize} from 'aurelia-pal-browser';
 
 describe('collection length', () => {
@@ -36,5 +37,141 @@ describe('collection length', () => {
       observer.unsubscribe(callback);
       done();
     }, checkDelay * 2);
+  });
+});
+
+describe('addChangeRecord', () => {
+  var locator;
+  beforeAll(() => {
+    initialize();
+    locator = new ModifyCollectionObserver();
+    locator.lengthObserver = true;
+    locator.queued = true;
+  });
+
+  beforeEach(() => {
+    locator.changeRecords = null;
+  });
+
+  describe('splice record', () => {
+    it('should not change index when deleting last item - splice(3, 1)', ()=> {
+      let array = array = ['1', '2', '3'];
+      let record = {
+        type: 'splice',
+        object: array,
+        index: 3,
+        removed: ['4'],
+        addedCount: 0
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(3);
+    });
+
+    it('should set index of last item when index -1 - splice(-1, 1)', ()=> {
+      let array = array = ['1', '2', '3'];
+      let record = {
+        type: 'splice',
+        object: array,
+        index: -1,
+        removed: ['4'],
+        addedCount: 0
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(3);
+    });
+
+    it('should set index of second last item when index -2 - splice(-2, 1)', ()=> {
+      let array = array = ['1', '2', '4'];
+        let record = {
+         type: 'splice',
+         object: array,
+         index: -2,
+         removed: ['3'],
+         addedCount: 0
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(2);
+    });
+
+    it('should set index of second last item when index -1 and adding 1 - splice(-1, 0, "Foo")', ()=> {
+      let array = array = ['1', '2', '3', 'Foo', '4'];
+        let record = {
+         type: 'splice',
+         object: array,
+         index: -1,
+         removed: [],
+         addedCount: 1
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(3);
+    });
+
+    it('should set index of third last item when index -2 and adding 1 - splice(-2, 0, "Foo")', ()=> {
+      let array = array = ['1', '2', 'Foo', '3', '4'];
+        let record = {
+         type: 'splice',
+         object: array,
+         index: -2,
+         removed: [],
+         addedCount: 1
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(2);
+    });
+
+    it('should set index of third last item when index -1 and adding 1 - splice(-1, 0, "Foo", "Bar")', ()=> {
+      let array = ['1', '2', '3', 'Foo', 'Bar', '4'];
+        let record = {
+         type: 'splice',
+         object: array,
+         index: -1,
+         removed: [],
+         addedCount: 2
+       };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(3);
+    });
+
+    it('should set index of second last item on index -1 removing 1 adding 1  - splice(-1, 1, "Foo")', ()=> {
+      let array = array = ['1', '2', '3', 'Foo'];
+      let record = {
+       type: 'splice',
+       object: array,
+       index: -1,
+       removed: ['4'],
+       addedCount: 1
+      };
+
+      locator.addChangeRecord(record);
+
+      expect(locator.changeRecords[0].index).toBe(3);
+    });
+
+    it('should set index to array length minus added count when index bigger than array - splice(6, 0, "Foo")', ()=> {
+      let array = array = ['1', '2', '3', '4', 'Foo'];
+      let record = {
+       type: 'splice',
+       object: array,
+       index: 6,
+       removed: [],
+       addedCount: 1
+      };
+
+       locator.addChangeRecord(record);
+
+       expect(locator.changeRecords[0].index).toBe(4);
+    });
   });
 });


### PR DESCRIPTION
@EisenbergEffect @jdanyow Please see if this looks alright to you guys. I think I got all the scenarios I could come up with right this time and move the logic to the `ModifyCollectionObserver` instead. There might be more scenarios though. But this will also fix regression bug when deleting last item or array. If any issue I can take a look again in about 4-5 hours.