### PR TITLE
feat(typings): added missing aurelia-binding types

### DIFF
--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -3,8 +3,6 @@
  */
 declare module 'aurelia-binding' {
   import { Container } from 'aurelia-dependency-injection';
-  import { ViewResources }  from 'aurelia-templating';
-  
 
   /**
    * The "parallel" or "artificial" aspect of the binding scope. Provides access to the parent binding
@@ -60,7 +58,7 @@ declare module 'aurelia-binding' {
     static convention(name: string): ValueConverterResource;
     constructor(name: string);
     initialize(container: Container, target: any): void;
-    register(registry: ViewResources, name: string): void;
+    register(registry: any, name: string): void;
   }
   
   /**
@@ -70,7 +68,7 @@ declare module 'aurelia-binding' {
     static convention(name: string): BindingBehaviorResource;
     constructor(name: string);
     initialize(container: Container, target: any): void;
-    register(registry: ViewResources, name: string): void;
+    register(registry: any, name: string): void;
   }
   
   /**

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -2,6 +2,10 @@
  * A modern databinding library for JavaScript and HTML.
  */
 declare module 'aurelia-binding' {
+  import { Container } from 'aurelia-dependency-injection';
+  import { ViewResources }  from 'aurelia-templating';
+  
+
   /**
    * The "parallel" or "artificial" aspect of the binding scope. Provides access to the parent binding
    * context and stores contextual bindable members such as $event, $index, $odd, etc. Members on this
@@ -55,8 +59,8 @@ declare module 'aurelia-binding' {
   export class ValueConverterResource {
     static convention(name: string): ValueConverterResource;
     constructor(name: string);
-    initialize(container, target): void;
-    register(registry, name): void;
+    initialize(container: Container, target: any): void;
+    register(registry: ViewResources, name: string): void;
   }
   
   /**
@@ -65,8 +69,8 @@ declare module 'aurelia-binding' {
   export class BindingBehaviorResource {
     static convention(name: string): BindingBehaviorResource;
     constructor(name: string);
-    initialize(container, target): void;
-    register(registry, name): void;
+    initialize(container: Container, target: any): void;
+    register(registry: ViewResources, name: string): void;
   }
   
   /**


### PR DESCRIPTION
@EisenbergEffect: ref aurelia/binding#232, added missing types for `ValueConverterResource` and `BindingBehaviorResource` (`initialize` and `register` functions).