### PR TITLE
Support expression observation in the computedFrom

### DIFF
--- a/src/computed-observation.js
+++ b/src/computed-observation.js
@@ -1,4 +1,5 @@
 import {subscriberCollection} from './subscriber-collection';
+import {ExpressionObserver} from './binding-engine';
 
 const computedContext = 'ComputedPropertyObserver';
 
@@ -9,6 +10,7 @@ export class ComputedPropertyObserver {
     this.propertyName = propertyName;
     this.descriptor = descriptor;
     this.observerLocator = observerLocator;
+    this.parser = this.observerLocator.parser;
   }
 
   getValue(){
@@ -35,7 +37,7 @@ export class ComputedPropertyObserver {
       let dependencies = this.descriptor.get.dependencies;
       this.observers = [];
       for (let i = 0, ii = dependencies.length; i < ii; i++) {
-        let observer = this.observerLocator.getObserver(this.obj, dependencies[i]);
+        let observer = new ExpressionObserver(this.obj, this.parser.parse(dependencies[i]), this.observerLocator);
         // todo:  consider throwing when a dependency's observer is an instance of DirtyCheckProperty.
         this.observers.push(observer);
         observer.subscribe(computedContext, this);

--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -3,6 +3,7 @@ import {TaskQueue} from 'aurelia-task-queue';
 import {getArrayObserver} from './array-observation';
 import {getMapObserver} from './map-observation';
 import {EventManager} from './event-manager';
+import {Parser} from './parser';
 import {DirtyChecker, DirtyCheckProperty} from './dirty-checking';
 import {
   SetterObserver,
@@ -26,14 +27,15 @@ import {
 import {SVGAnalyzer} from './svg';
 
 export class ObserverLocator {
-  static inject = [TaskQueue, EventManager, DirtyChecker, SVGAnalyzer];
+  static inject = [TaskQueue, EventManager, DirtyChecker, SVGAnalyzer, Parser];
 
-  constructor(taskQueue, eventManager, dirtyChecker, svgAnalyzer) {
+  constructor(taskQueue, eventManager, dirtyChecker, svgAnalyzer, parser) {
     this.taskQueue = taskQueue;
     this.eventManager = eventManager;
     this.dirtyChecker = dirtyChecker;
     this.svgAnalyzer = svgAnalyzer;
     this.adapters = [];
+    this.parser = parser;
   }
 
   getObserver(obj, propertyName) {


### PR DESCRIPTION
In the `computedFrom` decorator, currently it is not possible to use the following syntax:

```
@computedFrom("myItem.itemsChanged")
```

Apart from this, I have a use case where it would be nice to have a referenced item in the template:

```
<template>

    <my-custom-list ref="customList"></my-custom-list> 

</template>
```

and in the code base:

```
@computedFrom("customList.itemsChanged")
get routeForCreate() {
    ///...etc
}
```

Doing the above would help greatly reduce the need to both observe when "customList" is available and consequently observe the "itemsChanged" on that custom list.