### PR TITLE
fix(StyleObserver): parse style without breaking urls

### DIFF
--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -79,7 +79,7 @@ export class StyleObserver {
         }
       }
       else if ( newValue.length ) {
-        let pairs = newValue.split(/(?:[:;]\s*)/);
+        let pairs = newValue.split(/(?:;|:(?!\/))\s*/);
         for( let i = 0, length = pairs.length; i < length; i++ )
         {
           style = pairs[i];

--- a/test/element-observation.spec.js
+++ b/test/element-observation.spec.js
@@ -156,27 +156,31 @@ describe('element observation', () => {
       expect(observer instanceof StyleObserver).toBe(true);
       expect(() => observer.subscribe(() => {})).toThrow(new Error('Observation of a "DIV" element\'s "' + attrs[i] + '" property is not supported.'));
 
-      observer.setValue('width: 30px; height: 20px; background-color: red;');
-      expect(observer.getValue()).toBe('width: 30px; height: 20px; background-color: red;');
+      observer.setValue('width: 30px; height:20px; background-color: red;background-image: url("http://aurelia.io/test.png");');
+      expect(observer.getValue()).toBe('width: 30px; height: 20px; background-image: url("http://aurelia.io/test.png"); background-color: red;');
       expect(el.style.height).toBe('20px');
       expect(el.style.width).toBe('30px');
       expect(el.style.backgroundColor).toBe('red');
+      expect(el.style.backgroundImage).toBe('url("http://aurelia.io/test.png")');
 
       observer.setValue('');
       expect(el.style.height).toBe('');
       expect(el.style.width).toBe('');
       expect(el.style.backgroundColor).toBe('');
+      expect(el.style.backgroundImage).toBe('');
 
-      observer.setValue({ width: '50px', height: '40px', 'background-color': 'blue' });
-      expect(observer.getValue()).toBe('width: 50px; height: 40px; background-color: blue;');
+      observer.setValue({ width: '50px', height: '40px', 'background-color': 'blue', 'background-image': 'url("http://aurelia.io/test2.png")' });
+      expect(observer.getValue()).toBe('width: 50px; height: 40px; background-image: url("http://aurelia.io/test2.png"); background-color: blue;');
       expect(el.style.height).toBe('40px');
       expect(el.style.width).toBe('50px');
       expect(el.style.backgroundColor).toBe('blue');
+      expect(el.style.backgroundImage).toBe('url("http://aurelia.io/test2.png")')
 
       observer.setValue({});
       expect(el.style.height).toBe('');
       expect(el.style.width).toBe('');
       expect(el.style.backgroundColor).toBe('');
+      expect(el.style.backgroundImage).toBe('');
     }
   });
 


### PR DESCRIPTION
Regex was splitting style strings at all : and breaking urls

Fixes #301