### PR TITLE
fixes for ObserverLocator

### DIFF
--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -12,8 +12,8 @@ let unshift = Array.prototype.unshift;
 
 Array.prototype.pop = function() {
   let methodCallResult = pop.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.addChangeRecord({
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.addChangeRecord({
       type: 'delete',
       object: this,
       name: this.length,
@@ -21,12 +21,12 @@ Array.prototype.pop = function() {
     });
   }
   return methodCallResult;
-}
+};
 
 Array.prototype.push = function() {
   let methodCallResult = push.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.addChangeRecord({
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.addChangeRecord({
       type: 'splice',
       object: this,
       index: this.length - arguments.length,
@@ -35,25 +35,25 @@ Array.prototype.push = function() {
     });
   }
   return methodCallResult;
-}
+};
 
 Array.prototype.reverse = function() {
   let oldArray;
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.flushChangeRecords();
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.flushChangeRecords();
     oldArray = this.slice();
   }
   let methodCallResult = reverse.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.reset(oldArray);
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.reset(oldArray);
   }
   return methodCallResult;
-}
+};
 
 Array.prototype.shift = function() {
   let methodCallResult = shift.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.addChangeRecord({
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.addChangeRecord({
       type: 'delete',
       object: this,
       name: 0,
@@ -65,21 +65,21 @@ Array.prototype.shift = function() {
 
 Array.prototype.sort = function() {
   let oldArray;
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.flushChangeRecords();
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.flushChangeRecords();
     oldArray = this.slice();
   }
   let methodCallResult = sort.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.reset(oldArray);
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.reset(oldArray);
   }
   return methodCallResult;
 };
 
 Array.prototype.splice = function() {
   let methodCallResult = splice.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.addChangeRecord({
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.addChangeRecord({
       type: 'splice',
       object: this,
       index: arguments[0],
@@ -92,8 +92,8 @@ Array.prototype.splice = function() {
 
 Array.prototype.unshift = function() {
   let methodCallResult = unshift.apply(this, arguments);
-  if (this.__arrayObserver !== undefined) {
-    this.__arrayObserver.addChangeRecord({
+  if (this.__array_observer__ !== undefined) {
+    this.__array_observer__.addChangeRecord({
       type: 'splice',
       object: this,
       index: 0,
@@ -105,7 +105,7 @@ Array.prototype.unshift = function() {
 };
 
 export function getArrayObserver(taskQueue, array) {
-  return ModifyArrayObserver.create(taskQueue, array);
+  return ModifyArrayObserver.for(taskQueue, array);
 }
 
 class ModifyArrayObserver extends ModifyCollectionObserver {
@@ -113,12 +113,19 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
     super(taskQueue, array);
   }
 
+  static for(taskQueue, array) {
+    if (!('__array_observer__' in array)) {
+      let observer = ModifyArrayObserver.create(taskQueue, array);
+      Object.defineProperty(
+        array,
+        '__array_observer__',
+        { value: observer, enumerable: false, configurable: false });
+    }
+    return array.__array_observer__;
+  }
+
   static create(taskQueue, array) {
     let observer = new ModifyArrayObserver(taskQueue, array);
-    Object.defineProperty(
-      array,
-      '__arrayObserver',
-      { value: observer, enumerable: false, configurable: false });
     return observer;
   }
 }

--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -5,12 +5,23 @@ import {ModifyCollectionObserver} from './collection-observation';
 let mapProto = Map.prototype;
 
 export function getMapObserver(taskQueue, map){
-  return ModifyMapObserver.create(taskQueue, map);
+  return ModifyMapObserver.for(taskQueue, map);
 }
 
 class ModifyMapObserver extends ModifyCollectionObserver {
   constructor(taskQueue, map){
     super(taskQueue, map);
+  }
+
+  static for(taskQueue, map) {
+    if (!('__map_observer__' in map)) {
+      let observer = ModifyMapObserver.create(taskQueue, map);
+      Object.defineProperty(
+        map,
+        '__map_observer__',
+        { value: observer, enumerable: false, configurable: false });
+    }
+    return map.__map_observer__;
   }
 
   static create(taskQueue, map) {
@@ -27,7 +38,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         oldValue: oldValue
       });
       return methodCallResult;
-    }
+    };
 
     map['delete'] = function () {
       let oldValue = map.get(arguments[0]);
@@ -39,7 +50,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         oldValue: oldValue
       });
       return methodCallResult;
-    }
+    };
 
     map['clear'] = function () {
       let methodCallResult = mapProto['clear'].apply(map, arguments);
@@ -48,7 +59,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         object: map
       });
       return methodCallResult;
-    }
+    };
 
     return observer;
   }

--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -190,27 +190,15 @@ export class ObserverLocator {
   }
 
   getArrayObserver(array){
-    if ('__array_observer__' in array) {
-      return array.__array_observer__;
-    }
-
-    return array.__array_observer__ = getArrayObserver(this.taskQueue, array);
+    return getArrayObserver(this.taskQueue, array);
   }
 
   getMapObserver(map){
-    if ('__map_observer__' in map) {
-      return map.__map_observer__;
-    }
-
-    return map.__map_observer__ = getMapObserver(this.taskQueue, map);
+    return getMapObserver(this.taskQueue, map);
   }
 
   getSetObserver(set){
-    if ('__set_observer__' in set) {
-      return set.__set_observer__;
-    }
-
-    return set.__set_observer__ = getSetObserver(this.taskQueue, set);
+    return getSetObserver(this.taskQueue, set);
   }
 }
 

--- a/src/set-observation.js
+++ b/src/set-observation.js
@@ -5,12 +5,23 @@ import {ModifyCollectionObserver} from './collection-observation';
 let setProto = Set.prototype;
 
 export function getSetObserver(taskQueue, set){
-  return ModifySetObserver.create(taskQueue, set);
+  return ModifySetObserver.for(taskQueue, set);
 }
 
 class ModifySetObserver extends ModifyCollectionObserver {
   constructor(taskQueue, set){
     super(taskQueue, set);
+  }
+
+  static for(taskQueue, set) {
+    if (!('__set_observer__' in set)) {
+      let observer = ModifySetObserver.create(taskQueue, set);
+      Object.defineProperty(
+        set,
+        '__set_observer__',
+        { value: observer, enumerable: false, configurable: false });
+    }
+    return set.__set_observer__;
   }
 
   static create(taskQueue, set) {

--- a/test/array-observation.spec.js
+++ b/test/array-observation.spec.js
@@ -8,6 +8,14 @@ describe('array observation', () => {
     taskQueue = new TaskQueue();
   });
 
+  it('getArrayObserver should return same observer instance for one Array instance', () => {
+    let array = ['foo', 'bar', 'hello', 'world'];
+    let observer1 = getArrayObserver(taskQueue, array);
+    let observer2 = getArrayObserver(taskQueue, array);
+
+    expect(observer1 === observer2).toBe(true);
+  });
+
   it('pops', () => {
     let array = ['foo', 'bar', 'hello', 'world'];
     array.pop();


### PR DESCRIPTION
Should not relay on private property names
Should not create 2 private properties with same Observer instance for Arrays