### PR TITLE
fix(*-observation): allow binding extended Map/Set

### DIFF
--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -16,28 +16,40 @@ class ModifyMapObserver extends ModifyCollectionObserver {
   static create(taskQueue, map) {
     let observer = new ModifyMapObserver(taskQueue, map);
 
+    let methods = ['set', 'delete', 'clear'];
+    if (methods.find(m => mapProto[m] !== map[m])) {
+      mapProto = {};
+      methods.forEach(m => mapProto[m] = map[m]);
+    }
+
     map['set'] = function () {
+      let hasValue = map.has(arguments[0]);
+      let type = hasValue ? 'update' : 'add';
       let oldValue = map.get(arguments[0]);
-      let type = typeof oldValue !== 'undefined' ? 'update' : 'add';
       let methodCallResult = mapProto['set'].apply(map, arguments);
-      observer.addChangeRecord({
-        type: type,
-        object: map,
-        key: arguments[0],
-        oldValue: oldValue
-      });
+      if (!hasValue || oldValue !== map.get(arguments[0])) {
+        observer.addChangeRecord({
+          type: type,
+          object: map,
+          key: arguments[0],
+          oldValue: oldValue
+        });
+      }
       return methodCallResult;
     }
 
     map['delete'] = function () {
+      let hasValue = map.has(arguments[0]);
       let oldValue = map.get(arguments[0]);
       let methodCallResult = mapProto['delete'].apply(map, arguments);
-      observer.addChangeRecord({
-        type: 'delete',
-        object: map,
-        key: arguments[0],
-        oldValue: oldValue
-      });
+      if (hasValue) {
+        observer.addChangeRecord({
+          type: 'delete',
+          object: map,
+          key: arguments[0],
+          oldValue: oldValue
+        });
+      }
       return methodCallResult;
     }
 

--- a/src/set-observation.js
+++ b/src/set-observation.js
@@ -16,15 +16,22 @@ class ModifySetObserver extends ModifyCollectionObserver {
   static create(taskQueue, set) {
     let observer = new ModifySetObserver(taskQueue, set);
 
+    let methods = ['add', 'delete', 'clear'];
+    if (methods.find(m => setProto[m] !== set[m])) {
+      setProto = {};
+      methods.forEach(m => setProto[m] = set[m]);
+    }
+
     set['add'] = function () {
       let type = 'add';
-      let hasValue = set.has(arguments[0]);
+      let oldSize = set.size;
       let methodCallResult = setProto['add'].apply(set, arguments);
+      let hasValue = set.size === oldSize;
       if (!hasValue) {
         observer.addChangeRecord({
           type: type,
           object: set,
-          value: arguments[0]
+          value: Array.from(set).pop()
         });
       }
       return methodCallResult;

--- a/test/map-observation.spec.js
+++ b/test/map-observation.spec.js
@@ -4,21 +4,145 @@ import {initialize} from 'aurelia-pal-browser';
 
 describe('ModifyMapObserver', () => {
   let taskQueue;
+  let map;
+  let observer;
+  let callback;
   beforeAll(() => {
     initialize();
     taskQueue = new TaskQueue();
   });
 
-  it('identifies set with falsey oldValue as an "update"', done => {
-    let map = new Map();
-    map.set('foo', 0); // falsey old value.
-    let observer = getMapObserver(taskQueue, map);
-    let callback = jasmine.createSpy('callback');
+  beforeEach(() => {
+    map = new Map([['foo', 'bar'], ['falsy', undefined]]);
+    observer = getMapObserver(taskQueue, map);
+    callback = jasmine.createSpy('callback');
     observer.subscribe(callback);
-    map.set('foo', 'bar');
+  });
+
+  it('should add "add" changeRecord on set without oldValue', done => {
+    map.set('bar', 'foo');
     taskQueue.queueMicroTask({
       call: () => {
-        expect(callback).toHaveBeenCalledWith([{ type: 'update', object: map, key: 'foo', oldValue: 0 }], undefined);
+        expect(callback).toHaveBeenCalledWith([{ type: 'add', object: map, key: 'bar', oldValue: undefined }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should add "update" changeRecord on set with existing oldValue', done => {
+    map.set('foo', 'baz');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'update', object: map, key: 'foo', oldValue: 'bar' }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should add "update" changeRecord on set with falsy oldValue', done => {
+    map.set('falsy', 'baz');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'update', object: map, key: 'falsy', oldValue: undefined }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should add changeRecord on delete', done => {
+    map.delete('foo');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'delete', object: map, key: 'foo', oldValue: 'bar' }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should not add changeRecord on delete when key does not exist', done => {
+    map.delete('baz');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).not.toHaveBeenCalled();
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should add changeRecord on clear', done => {
+    map.clear();
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'clear', object: map }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+});
+
+describe('ModifyMapObserver of extended Map', () => {
+  let taskQueue;
+  let map;
+  let observer;
+  let callback;
+  function createNumericMap() {
+    let m = new Map();
+    m.set = function(k, v) {
+      if (typeof v !== 'number') {
+        v = 0;
+      }
+      Map.prototype.set.call(this, k, v);
+      return this;
+    };
+    return m;
+  }
+  beforeAll(() => {
+    initialize();
+    taskQueue = new TaskQueue();
+  });
+
+  beforeEach(() => {
+    map = createNumericMap();
+    map.set('one', 1);
+    map.set('zero', 0);
+    observer = getMapObserver(taskQueue, map);
+    callback = jasmine.createSpy('callback');
+    observer.subscribe(callback);
+  });
+
+  it('should add "update" changeRecord on set with a chanced altered value', done => {
+    map.set('one', 'one');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'update', object: map, key: 'one', oldValue: 1 }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should add "add" changeRecord on set with a new altered value', done => {
+    map.set('two', 'two');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).toHaveBeenCalledWith([{ type: 'add', object: map, key: 'two', oldValue: undefined }], undefined);
+        observer.unsubscribe(callback);
+        done();
+      }
+    });
+  });
+
+  it('should not add changeRecord on set with an unchanged altered value', done => {
+    map.set('zero', 'zero');
+    taskQueue.queueMicroTask({
+      call: () => {
+        expect(callback).not.toHaveBeenCalled();
         observer.unsubscribe(callback);
         done();
       }


### PR DESCRIPTION
As far as I understood it is not possible to extend Maps & Sets using the Babel transpiler (at least for now). That's  too bad, as I would like to create a class similar to this:
```
export NumericSet extends Set {
  constructor() {
  }

  add(val) {
    if (typeof val === 'number') {
      super.add(val);
    }
  }
}
```

As expected, when I transpile this using Babel I get the following error:
```
TypeError: Method Set.prototype.add called on incompatible receiver #<NumericSet>
```

I tried to overcome this issue by overwriting the `add` method of my Set instance directly. Unfortunately, this does not work either, as Aurelia overwrites my `add` method using the native `Set.prototype.add`.

This PR could help me out be calling the `add` method directly rather than using the prototype by default. I've changed the `ModifyMapObserver` in a similar fashion.