### PR TITLE
fix (observer-locator): observer locator for collections must return same instance of Observer for same instance collection

### DIFF
--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -5,12 +5,29 @@ import {ModifyCollectionObserver} from './collection-observation';
 let mapProto = Map.prototype;
 
 export function getMapObserver(taskQueue, map){
-  return ModifyMapObserver.create(taskQueue, map);
+  return ModifyMapObserver.for(taskQueue, map);
 }
 
 class ModifyMapObserver extends ModifyCollectionObserver {
   constructor(taskQueue, map){
     super(taskQueue, map);
+  }
+
+  /**
+   * Searches for observer or creates a new one associated with given map instance
+   * @param taskQueue
+   * @param map instance for which observer is searched
+   * @returns ModifyMapObserver always the same instance for any given map instance
+   */
+  static for(taskQueue, map) {
+    if (!('__map_observer__' in map)) {
+      let observer = ModifyMapObserver.create(taskQueue, map);
+      Object.defineProperty(
+        map,
+        '__map_observer__',
+        { value: observer, enumerable: false, configurable: false });
+    }
+    return map.__map_observer__;
   }
 
   static create(taskQueue, map) {
@@ -27,7 +44,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         oldValue: oldValue
       });
       return methodCallResult;
-    }
+    };
 
     map['delete'] = function () {
       let oldValue = map.get(arguments[0]);
@@ -39,7 +56,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         oldValue: oldValue
       });
       return methodCallResult;
-    }
+    };
 
     map['clear'] = function () {
       let methodCallResult = mapProto['clear'].apply(map, arguments);
@@ -48,7 +65,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
         object: map
       });
       return methodCallResult;
-    }
+    };
 
     return observer;
   }

--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -190,27 +190,15 @@ export class ObserverLocator {
   }
 
   getArrayObserver(array){
-    if ('__array_observer__' in array) {
-      return array.__array_observer__;
-    }
-
-    return array.__array_observer__ = getArrayObserver(this.taskQueue, array);
+    return getArrayObserver(this.taskQueue, array);
   }
 
   getMapObserver(map){
-    if ('__map_observer__' in map) {
-      return map.__map_observer__;
-    }
-
-    return map.__map_observer__ = getMapObserver(this.taskQueue, map);
+    return getMapObserver(this.taskQueue, map);
   }
 
   getSetObserver(set){
-    if ('__set_observer__' in set) {
-      return set.__set_observer__;
-    }
-
-    return set.__set_observer__ = getSetObserver(this.taskQueue, set);
+    return getSetObserver(this.taskQueue, set);
   }
 }
 

--- a/src/set-observation.js
+++ b/src/set-observation.js
@@ -5,12 +5,29 @@ import {ModifyCollectionObserver} from './collection-observation';
 let setProto = Set.prototype;
 
 export function getSetObserver(taskQueue, set){
-  return ModifySetObserver.create(taskQueue, set);
+  return ModifySetObserver.for(taskQueue, set);
 }
 
 class ModifySetObserver extends ModifyCollectionObserver {
   constructor(taskQueue, set){
     super(taskQueue, set);
+  }
+
+  /**
+   * Searches for observer or creates a new one associated with given set instance
+   * @param taskQueue
+   * @param set instance for which observer is searched
+   * @returns ModifySetObserver always the same instance for any given set instance
+   */
+  static for(taskQueue, set) {
+    if (!('__set_observer__' in set)) {
+      let observer = ModifySetObserver.create(taskQueue, set);
+      Object.defineProperty(
+        set,
+        '__set_observer__',
+        { value: observer, enumerable: false, configurable: false });
+    }
+    return set.__set_observer__;
   }
 
   static create(taskQueue, set) {
@@ -28,7 +45,7 @@ class ModifySetObserver extends ModifyCollectionObserver {
         });
       }
       return methodCallResult;
-    }
+    };
 
     set['delete'] = function () {
       let hasValue = set.has(arguments[0]);
@@ -41,7 +58,7 @@ class ModifySetObserver extends ModifyCollectionObserver {
         });
       }
       return methodCallResult;
-    }
+    };
 
     set['clear'] = function () {
       let methodCallResult = setProto['clear'].apply(set, arguments);
@@ -50,7 +67,7 @@ class ModifySetObserver extends ModifyCollectionObserver {
         object: set
       });
       return methodCallResult;
-    }
+    };
 
     return observer;
   }

--- a/test/array-observation.spec.js
+++ b/test/array-observation.spec.js
@@ -8,6 +8,23 @@ describe('array observation', () => {
     taskQueue = new TaskQueue();
   });
 
+  it('getArrayObserver should return same observer instance for the same Array instance', () => {
+    let array = ['foo', 'bar', 'hello', 'world'];
+    let observer1 = getArrayObserver(taskQueue, array);
+    let observer2 = getArrayObserver(taskQueue, array);
+
+    expect(observer1 === observer2).toBe(true);
+  });
+
+  it('getArrayObserver should return different observer instances for different Array instances', () => {
+    let array1 = ['foo', 'bar', 'hello', 'world'];
+    let array2 = ['foo', 'bar', 'hello', 'world'];
+    let observer1 = getArrayObserver(taskQueue, array1);
+    let observer2 = getArrayObserver(taskQueue, array2);
+
+    expect(observer1 !== observer2).toBe(true);
+  });
+
   it('pops', () => {
     let array = ['foo', 'bar', 'hello', 'world'];
     array.pop();

--- a/test/map-observation.spec.js
+++ b/test/map-observation.spec.js
@@ -9,6 +9,23 @@ describe('ModifyMapObserver', () => {
     taskQueue = new TaskQueue();
   });
 
+  it('getMapObserver should return same observer instance for the same Map instance', () => {
+    let map = new Map();
+    let observer1 = getMapObserver(taskQueue, map);
+    let observer2 = getMapObserver(taskQueue, map);
+
+    expect(observer1 === observer2).toBe(true);
+  });
+
+  it('getMapObserver should return different observer instances for different Map instances', () => {
+    let map1 = new Map();
+    let map2 = new Map();
+    let observer1 = getMapObserver(taskQueue, map1);
+    let observer2 = getMapObserver(taskQueue, map2);
+
+    expect(observer1 !== observer2).toBe(true);
+  });
+
   it('identifies set with falsey oldValue as an "update"', done => {
     let map = new Map();
     map.set('foo', 0); // falsey old value.

--- a/test/set-observation.spec.js
+++ b/test/set-observation.spec.js
@@ -17,7 +17,24 @@ describe('ModifySetObserver', () => {
     observer = getSetObserver(taskQueue, set);
     callback = jasmine.createSpy('callback');
     observer.subscribe(callback);
-  })
+  });
+
+  it('getSetObserver should return same observer instance for the same Set instance', () => {
+    let set = new Set();
+    let observer1 = getSetObserver(taskQueue, set);
+    let observer2 = getSetObserver(taskQueue, set);
+
+    expect(observer1 === observer2).toBe(true);
+  });
+
+  it('getSetObserver should return different observer instances for different Set instances', () => {
+    let set1 = new Set();
+    let set2 = new Set();
+    let observer1 = getSetObserver(taskQueue, set1);
+    let observer2 = getSetObserver(taskQueue, set2);
+
+    expect(observer1 !== observer2).toBe(true);
+  });
 
   it('should add changeRecord on add', done => {
     set.add('baz');


### PR DESCRIPTION
I have noted that for Array instance Observer created in two distinct private properties. Even more, those instances where not the same depending on which API you use to create and retrieve them. This PR fixes management of observers for Collection types by ensuring that for one given instance of collection always will be only one MutationObserver instance.