### PR TITLE
Log warning when property can't be defined

### DIFF
--- a/config.js
+++ b/config.js
@@ -15,6 +15,7 @@ System.config({
 
   map: {
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.1.2",
+    "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.1.2",
     "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.1.3",
     "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.1.1",
     "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.1.2",

--- a/package.json
+++ b/package.json
@@ -27,11 +27,13 @@
       "dist": "dist/amd"
     },
     "peerDependencies": {
+      "aurelia-logging": "^1.0.0-beta.1.1.2",
       "aurelia-metadata": "^1.0.0-beta.1.1.3",
       "aurelia-pal": "^1.0.0-beta.1.1.1",
       "aurelia-task-queue": "^1.0.0-beta.1.1.0"
     },
     "dependencies": {
+      "aurelia-logging": "^1.0.0-beta.1.1.2",
       "aurelia-metadata": "^1.0.0-beta.1.1.3",
       "aurelia-pal": "^1.0.0-beta.1.1.1",
       "aurelia-task-queue": "^1.0.0-beta.1.1.0"

--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -123,7 +123,7 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
   static for(taskQueue, array) {
     if (!('__array_observer__' in array)) {
       let observer = ModifyArrayObserver.create(taskQueue, array);
-      Object.defineProperty(
+      Reflect.defineProperty(
         array,
         '__array_observer__',
         { value: observer, enumerable: false, configurable: false });

--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -39,7 +39,7 @@ export function observable(targetOrConfig, key, descriptor) {
     descriptor2.get.dependencies = [innerPropertyName];
 
     if (!babel) {
-      Object.defineProperty(target, key2, descriptor2);
+      Reflect.defineProperty(target, key2, descriptor2);
     }
   };
 

--- a/src/map-observation.js
+++ b/src/map-observation.js
@@ -20,7 +20,7 @@ class ModifyMapObserver extends ModifyCollectionObserver {
   static for(taskQueue, map) {
     if (!('__map_observer__' in map)) {
       let observer = ModifyMapObserver.create(taskQueue, map);
-      Object.defineProperty(
+      Reflect.defineProperty(
         map,
         '__map_observer__',
         { value: observer, enumerable: false, configurable: false });

--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -1,3 +1,4 @@
+import * as LogManager from 'aurelia-logging';
 import {DOM} from 'aurelia-pal';
 import {TaskQueue} from 'aurelia-task-queue';
 import {getArrayObserver} from './array-observation';
@@ -26,6 +27,8 @@ import {
   createComputedObserver
 } from './computed-observation';
 import {SVGAnalyzer} from './svg';
+
+const logger = LogManager.getLogger('observer-locator');
 
 export class ObserverLocator {
   static inject = [TaskQueue, EventManager, DirtyChecker, SVGAnalyzer, Parser];
@@ -67,14 +70,14 @@ export class ObserverLocator {
   createObserversLookup(obj) {
     let value = {};
 
-    try {
-      Object.defineProperty(obj, '__observers__', {
-        enumerable: false,
-        configurable: false,
-        writable: false,
-        value: value
-      });
-    } catch(_) {} // eslint-disable-line
+    if (!Reflect.defineProperty(obj, '__observers__', {
+      enumerable: false,
+      configurable: false,
+      writable: false,
+      value: value
+    })) {
+      logger.warn('Cannot add observers to object', obj);
+    }
 
     return value;
   }

--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -1,4 +1,7 @@
+import * as LogManager from 'aurelia-logging';
 import {subscriberCollection} from './subscriber-collection';
+
+const logger = LogManager.getLogger('property-observation');
 
 export const propertyAccessor = {
   getValue: (obj, propertyName) => obj[propertyName],
@@ -91,13 +94,13 @@ export class SetterObserver {
     this.setValue = this.setterValue;
     this.getValue = this.getterValue;
 
-    try {
-      Object.defineProperty(this.obj, this.propertyName, {
-        configurable: true,
-        enumerable: true,
-        get: this.getValue.bind(this),
-        set: this.setValue.bind(this)
-      });
-    } catch(_) {} // eslint-disable-line
+    if (!Reflect.defineProperty(this.obj, this.propertyName, {
+      configurable: true,
+      enumerable: true,
+      get: this.getValue.bind(this),
+      set: this.setValue.bind(this)
+    })) {
+      logger.warn(`Cannot observe property '${this.propertyName}' of object`, this.obj);
+    }
   }
 }

--- a/src/set-observation.js
+++ b/src/set-observation.js
@@ -20,7 +20,7 @@ class ModifySetObserver extends ModifyCollectionObserver {
   static for(taskQueue, set) {
     if (!('__set_observer__' in set)) {
       let observer = ModifySetObserver.create(taskQueue, set);
-      Object.defineProperty(
+      Reflect.defineProperty(
         set,
         '__set_observer__',
         { value: observer, enumerable: false, configurable: false });


### PR DESCRIPTION
First of all, this PR is not complete.

For some types of objects I wish not to allow adding properties after initialization (using `Object.preventExtensions()`). However, this also prevents Aurelia from observing these properties, as defining the required extra properties using `Object.defineProperty` fails. Currently, this is being ignored silently. This purpose of this PR is to add logging to the situations where this might occur.
I've you find this PR useful, I can add loggers for the other `Object.defineProperty` occurrences as well.

By the way, I actually find `Reflect.defineProperty` to be a more elegant solution than try & catching. But as this requires an extra polyfill in aurelia-polyfills, I hereby first mention it as a suggestion.