### PR TITLE
fix(SelectValueObserver): select default option

### DIFF
--- a/src/select-value-observer.js
+++ b/src/select-value-observer.js
@@ -64,7 +64,7 @@ export class SelectValueObserver {
     while(i--) {
       let option = options.item(i);
       if (clear) {
-        option.selected = false;
+        option.selected = option.defaultSelected;
         continue;
       }
       let optionValue = option.hasOwnProperty('model') ? option.model : option.value;

--- a/test/select-value-observer.spec.js
+++ b/test/select-value-observer.spec.js
@@ -38,6 +38,25 @@ describe('SelectValueObserver', () => {
     return value;
   }
 
+  describe('default selection', () => {
+    var obj, el, binding;
+    beforeAll(() => {
+        obj = { selectedItem: null };
+        el = createElement(
+            `<select>
+            <option value="A">A</option>
+            <option value="B">B</option>
+            <option selected value="C">C</option>
+            </select>`);
+        document.body.appendChild(el);
+        binding = getBinding(observerLocator, obj, 'selectedItem', el, 'value', bindingMode.twoWay).binding;
+    });
+      
+    it('selects default', () => {
+        expect(el.value).toBe('C');
+    });
+  });
+
   describe('single-select strings', () => {
     var obj, el, binding;
 


### PR DESCRIPTION
Select the option the `selected` attribute by default when the value is not defined.

Fixes #364