### PR TITLE
chore(travis): add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - '0.12'
+  - '4'
+  - '5'
+
+sudo: false
+cache:
+  directories:
+    - node_modules
+
+script: gulp lint
+


### PR DESCRIPTION
This adds a simple TravisCI configuration to ensure that the project is always linted. If/when travis is enabled for this project, all commits/PRs will run travis jobs to catch early errors before code makes it into the main repo. Travis can also run karma tests via `xvfb` if we want to go down this road. 

/cc @bryanrsmith (I spoke with Rob and Jeremy about this, I believe you were working on CI at one point?) 