### PR TITLE
fix(CheckedObserver): synchronize on changes to input value

### DIFF
--- a/src/observer-locator.js
+++ b/src/observer-locator.js
@@ -179,6 +179,7 @@ export class ObserverLocator {
         || propertyName === 'style' || propertyName === 'css'
         || propertyName === 'value' && (obj.tagName.toLowerCase() === 'input' || obj.tagName.toLowerCase() === 'select')
         || propertyName === 'checked' && obj.tagName.toLowerCase() === 'input'
+        || propertyName === 'model' && obj.tagName.toLowerCase() === 'input'
         || /^xlink:.+$/.exec(propertyName)) {
         return this.getObserver(obj, propertyName);
       }

--- a/test/checked-observer.spec.js
+++ b/test/checked-observer.spec.js
@@ -22,6 +22,7 @@ describe('CheckedObserver', () => {
     beforeAll(() => {
       obj = { selectedItems: [] };
       el = createElement('<input type="checkbox" value="A" />');
+      observerLocator.getObserver(el, 'value');
       document.body.appendChild(el);
       binding = getBinding(observerLocator, obj, 'selectedItems', el, 'checked', bindingMode.twoWay).binding;
     });
@@ -36,6 +37,19 @@ describe('CheckedObserver', () => {
       setTimeout(() => {
         expect(el.checked).toBe(true);
         done();
+      }, 0);
+    });
+
+    it('responds to element value change', done => {
+      expect(el.checked).toBe(true);
+      el.__observers__.value.setValue('ZZZZ');
+      setTimeout(() => {
+        expect(el.checked).toBe(false);
+        el.__observers__.value.setValue('A');
+        setTimeout(() => {
+          expect(el.checked).toBe(true);
+          done();
+        });
       }, 0);
     });
 
@@ -77,6 +91,7 @@ describe('CheckedObserver', () => {
       obj = { selectedItems: [], itemA: {} };
       el = createElement('<input type="checkbox" />');
       el.model = obj.itemA;
+      observerLocator.getObserver(el, 'model');
       document.body.appendChild(el);
       binding = getBinding(observerLocator, obj, 'selectedItems', el, 'checked', bindingMode.twoWay).binding;
     });
@@ -91,6 +106,19 @@ describe('CheckedObserver', () => {
       setTimeout(() => {
         expect(el.checked).toBe(true);
         done();
+      }, 0);
+    });
+
+    it('responds to element value change', done => {
+      expect(el.checked).toBe(true);
+      el.__observers__.model.setValue({});
+      setTimeout(() => {
+        expect(el.checked).toBe(false);
+        el.__observers__.model.setValue(obj.itemA);
+        setTimeout(() => {
+          expect(el.checked).toBe(true);
+          done();
+        });
       }, 0);
     });
 

--- a/test/observer-locator.spec.js
+++ b/test/observer-locator.spec.js
@@ -165,4 +165,8 @@ describe('ObserverLocator', () => {
   it('getAccessor returns ValueAttributeObserver for input.value', () => {
     expect(locator.getAccessor(document.createElement('input'), 'value') instanceof ValueAttributeObserver).toBe(true);
   });
+
+  it('getAccessor returns SetterObserver for input.model', () => {
+    expect(locator.getAccessor(document.createElement('input'), 'model') instanceof SetterObserver).toBe(true);
+  });
 });


### PR DESCRIPTION
When checkbox/radio's value attribute is data-bound, observe it for changes and synchronize the element's checked status accordingly

fixes #320