### PR TITLE
feat(cachedComputedFrom): decorator for computed properties with caching

### DIFF
--- a/dist/amd/aurelia-binding.d.ts
+++ b/dist/amd/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/dist/amd/aurelia-binding.js
+++ b/dist/amd/aurelia-binding.js
@@ -4235,7 +4235,13 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
         var _this26 = this;
 
         var cached = dependencies.reduce(function (cached, dependency) {
-          return cached && cache[dependency] == dependencyAccess(_this26, dependency);
+          var key = void 0;
+          if (typeof dependency === "string") {
+            key = dependency;
+          } else {
+            key = dependency.name;
+          }
+          return cached && cache[key] == dependencyAccess(_this26, dependency);
         }, true);
 
         if (!cached) {

--- a/dist/amd/aurelia-binding.js
+++ b/dist/amd/aurelia-binding.js
@@ -4225,6 +4225,16 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
       return value;
     };
 
+    var dependencyKey = function dependencyKey(dependency) {
+      var key = void 0;
+      if (typeof dependency === "string") {
+        key = dependency;
+      } else {
+        key = dependency.name;
+      }
+      return key;
+    };
+
     return function (target, key, descriptor) {
       var _descriptor = descriptor.get;
       var dependencies = rest;
@@ -4235,30 +4245,22 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
         var _this26 = this;
 
         var cached = dependencies.reduce(function (cached, dependency) {
-          var key = void 0;
-          if (typeof dependency === "string") {
-            key = dependency;
-          } else {
-            key = dependency.name;
-          }
+          var key = dependencyKey(dependency);
           return cached && cache[key] == dependencyAccess(_this26, dependency);
         }, true);
 
         if (!cached) {
           dependencies.map(function (dependency) {
-            var key = void 0;
-            if (typeof dependency === "string") {
-              key = dependency;
-            } else {
-              key = dependency.name;
-            }
+            var key = dependencyKey(dependency);
             return cache[key] = dependencyAccess(_this26, dependency);
           });
           store = _descriptor.call(this);
         }
+
         return store;
       };
       descriptor.get.dependencies = rest;
+
       return descriptor;
     };
   }

--- a/dist/amd/aurelia-binding.js
+++ b/dist/amd/aurelia-binding.js
@@ -4244,10 +4244,10 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
       descriptor.get = function () {
         var _this26 = this;
 
-        var cached = dependencies.reduce(function (cached, dependency) {
+        var cached = dependencies.every(function (dependency) {
           var key = dependencyKey(dependency);
-          return cached && cache[key] == dependencyAccess(_this26, dependency);
-        }, true);
+          return cache[key] && cache[key] == dependencyAccess(_this26, dependency);
+        });
 
         if (!cached) {
           dependencies.map(function (dependency) {

--- a/dist/aurelia-binding.d.ts
+++ b/dist/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/dist/aurelia-binding.js
+++ b/dist/aurelia-binding.js
@@ -3988,7 +3988,13 @@ export function cachedComputedFrom(...rest) {
     descriptor.get = function() {
 
       const cached = dependencies.reduce((cached, dependency) => {
-        return cached && cache[dependency] == dependencyAccess(this,dependency) ;
+        let key;
+        if (typeof dependency === "string") {
+          key = dependency;
+        } else {
+          key = dependency.name;
+        }
+        return cached && cache[key] == dependencyAccess(this,dependency) ;
       }, true);
 
       if (!cached) {

--- a/dist/aurelia-binding.js
+++ b/dist/aurelia-binding.js
@@ -3979,6 +3979,16 @@ export function cachedComputedFrom(...rest) {
     return value;
   };
 
+  const dependencyKey = (dependency) => {
+    let key;
+    if (typeof dependency === "string") {
+      key = dependency;
+    } else {
+      key = dependency.name;
+    }
+    return key;
+  };
+
   return function(target, key, descriptor) {
     const _descriptor = descriptor.get;
     const dependencies = rest;
@@ -3986,32 +3996,23 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function() {
-
       const cached = dependencies.reduce((cached, dependency) => {
-        let key;
-        if (typeof dependency === "string") {
-          key = dependency;
-        } else {
-          key = dependency.name;
-        }
+        const key = dependencyKey(dependency);
         return cached && cache[key] == dependencyAccess(this,dependency) ;
       }, true);
 
       if (!cached) {
         dependencies.map((dependency) => {
-          let key;
-          if (typeof dependency === "string") {
-            key = dependency;
-          } else {
-            key = dependency.name;
-          }
+          const key = dependencyKey(dependency);
           return cache[key] = dependencyAccess(this,dependency);
         });
         store = _descriptor.call(this);
       }
+
       return store;
     };
     descriptor.get.dependencies = rest;
+
     return descriptor;
   };
 }

--- a/dist/aurelia-binding.js
+++ b/dist/aurelia-binding.js
@@ -3996,10 +3996,10 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function() {
-      const cached = dependencies.reduce((cached, dependency) => {
+      const cached = dependencies.every((dependency) => {
         const key = dependencyKey(dependency);
-        return cached && cache[key] == dependencyAccess(this,dependency) ;
-      }, true);
+        return cache[key] && cache[key] == dependencyAccess(this,dependency) ;
+      });
 
       if (!cached) {
         dependencies.map((dependency) => {

--- a/dist/commonjs/aurelia-binding.d.ts
+++ b/dist/commonjs/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -4197,10 +4197,10 @@ function cachedComputedFrom() {
     descriptor.get = function () {
       var _this26 = this;
 
-      var cached = dependencies.reduce(function (cached, dependency) {
+      var cached = dependencies.every(function (dependency) {
         var key = dependencyKey(dependency);
-        return cached && cache[key] == dependencyAccess(_this26, dependency);
-      }, true);
+        return cache[key] && cache[key] == dependencyAccess(_this26, dependency);
+      });
 
       if (!cached) {
         dependencies.map(function (dependency) {

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -4178,6 +4178,16 @@ function cachedComputedFrom() {
     return value;
   };
 
+  var dependencyKey = function dependencyKey(dependency) {
+    var key = void 0;
+    if (typeof dependency === "string") {
+      key = dependency;
+    } else {
+      key = dependency.name;
+    }
+    return key;
+  };
+
   return function (target, key, descriptor) {
     var _descriptor = descriptor.get;
     var dependencies = rest;
@@ -4188,30 +4198,22 @@ function cachedComputedFrom() {
       var _this26 = this;
 
       var cached = dependencies.reduce(function (cached, dependency) {
-        var key = void 0;
-        if (typeof dependency === "string") {
-          key = dependency;
-        } else {
-          key = dependency.name;
-        }
+        var key = dependencyKey(dependency);
         return cached && cache[key] == dependencyAccess(_this26, dependency);
       }, true);
 
       if (!cached) {
         dependencies.map(function (dependency) {
-          var key = void 0;
-          if (typeof dependency === "string") {
-            key = dependency;
-          } else {
-            key = dependency.name;
-          }
+          var key = dependencyKey(dependency);
           return cache[key] = dependencyAccess(_this26, dependency);
         });
         store = _descriptor.call(this);
       }
+
       return store;
     };
     descriptor.get.dependencies = rest;
+
     return descriptor;
   };
 }

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -26,6 +26,7 @@ exports.cloneExpression = cloneExpression;
 exports.hasDeclaredDependencies = hasDeclaredDependencies;
 exports.declarePropertyDependencies = declarePropertyDependencies;
 exports.computedFrom = computedFrom;
+exports.cachedComputedFrom = cachedComputedFrom;
 exports.createComputedObserver = createComputedObserver;
 exports.valueConverter = valueConverter;
 exports.bindingBehavior = bindingBehavior;
@@ -4158,18 +4159,69 @@ function computedFrom() {
   };
 }
 
+function cachedComputedFrom() {
+  for (var _len2 = arguments.length, rest = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+    rest[_key2] = arguments[_key2];
+  }
+
+  var dependencyAccess = function dependencyAccess(object, dependency) {
+    var value = void 0;
+
+    if (typeof dependency === "string") {
+      value = dependency.split('.').reduce(function (subjObject, subdependency) {
+        return subjObject[subdependency];
+      }, object);
+    } else {
+      var scope = { bindingContext: object, overrideContext: createOverrideContext(object) };
+      value = dependency.evaluate(scope, null);
+    }
+    return value;
+  };
+
+  return function (target, key, descriptor) {
+    var _descriptor = descriptor.get;
+    var dependencies = rest;
+    var store = void 0;
+    var cache = {};
+
+    descriptor.get = function () {
+      var _this26 = this;
+
+      var cached = dependencies.reduce(function (cached, dependency) {
+        return cached && cache[dependency] == dependencyAccess(_this26, dependency);
+      }, true);
+
+      if (!cached) {
+        dependencies.map(function (dependency) {
+          var key = void 0;
+          if (typeof dependency === "string") {
+            key = dependency;
+          } else {
+            key = dependency.name;
+          }
+          return cache[key] = dependencyAccess(_this26, dependency);
+        });
+        store = _descriptor.call(this);
+      }
+      return store;
+    };
+    descriptor.get.dependencies = rest;
+    return descriptor;
+  };
+}
+
 var ComputedExpression = exports.ComputedExpression = function (_Expression19) {
   _inherits(ComputedExpression, _Expression19);
 
   function ComputedExpression(name, dependencies) {
     
 
-    var _this26 = _possibleConstructorReturn(this, _Expression19.call(this));
+    var _this27 = _possibleConstructorReturn(this, _Expression19.call(this));
 
-    _this26.name = name;
-    _this26.dependencies = dependencies;
-    _this26.isAssignable = true;
-    return _this26;
+    _this27.name = name;
+    _this27.dependencies = dependencies;
+    _this27.isAssignable = true;
+    return _this27;
   }
 
   ComputedExpression.prototype.evaluate = function evaluate(scope, lookupFunctions) {
@@ -4795,7 +4847,7 @@ var Call = exports.Call = function () {
   };
 
   Call.prototype.bind = function bind(source) {
-    var _this27 = this;
+    var _this28 = this;
 
     if (this.isBound) {
       if (this.source === source) {
@@ -4810,7 +4862,7 @@ var Call = exports.Call = function () {
       this.sourceExpression.bind(this, source, this.lookupFunctions);
     }
     this.targetProperty.setValue(function ($event) {
-      return _this27.callSource($event);
+      return _this28.callSource($event);
     });
   };
 
@@ -4947,7 +4999,7 @@ var Listener = exports.Listener = function () {
   };
 
   Listener.prototype.bind = function bind(source) {
-    var _this28 = this;
+    var _this29 = this;
 
     if (this.isBound) {
       if (this.source === source) {
@@ -4962,7 +5014,7 @@ var Listener = exports.Listener = function () {
       this.sourceExpression.bind(this, source, this.lookupFunctions);
     }
     this._disposeListener = this.eventManager.addEventListener(this.target, this.targetEvent, function (event) {
-      return _this28.callSource(event);
+      return _this29.callSource(event);
     }, this.delegate);
   };
 
@@ -5094,11 +5146,11 @@ var BindingEngine = exports.BindingEngine = (_temp2 = _class13 = function () {
   };
 
   BindingEngine.prototype.propertyObserver = function propertyObserver(obj, propertyName) {
-    var _this29 = this;
+    var _this30 = this;
 
     return {
       subscribe: function subscribe(callback) {
-        var observer = _this29.observerLocator.getObserver(obj, propertyName);
+        var observer = _this30.observerLocator.getObserver(obj, propertyName);
         observer.subscribe(callback);
         return {
           dispose: function dispose() {
@@ -5110,17 +5162,17 @@ var BindingEngine = exports.BindingEngine = (_temp2 = _class13 = function () {
   };
 
   BindingEngine.prototype.collectionObserver = function collectionObserver(collection) {
-    var _this30 = this;
+    var _this31 = this;
 
     return {
       subscribe: function subscribe(callback) {
         var observer = void 0;
         if (collection instanceof Array) {
-          observer = _this30.observerLocator.getArrayObserver(collection);
+          observer = _this31.observerLocator.getArrayObserver(collection);
         } else if (collection instanceof Map) {
-          observer = _this30.observerLocator.getMapObserver(collection);
+          observer = _this31.observerLocator.getMapObserver(collection);
         } else if (collection instanceof Set) {
-          observer = _this30.observerLocator.getSetObserver(collection);
+          observer = _this31.observerLocator.getSetObserver(collection);
         } else {
           throw new Error('collection must be an instance of Array, Map or Set.');
         }

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -4188,7 +4188,13 @@ function cachedComputedFrom() {
       var _this26 = this;
 
       var cached = dependencies.reduce(function (cached, dependency) {
-        return cached && cache[dependency] == dependencyAccess(_this26, dependency);
+        var key = void 0;
+        if (typeof dependency === "string") {
+          key = dependency;
+        } else {
+          key = dependency.name;
+        }
+        return cached && cache[key] == dependencyAccess(_this26, dependency);
       }, true);
 
       if (!cached) {

--- a/dist/es2015/aurelia-binding.d.ts
+++ b/dist/es2015/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -3820,10 +3820,10 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function () {
-      const cached = dependencies.reduce((cached, dependency) => {
+      const cached = dependencies.every(dependency => {
         const key = dependencyKey(dependency);
-        return cached && cache[key] == dependencyAccess(this, dependency);
-      }, true);
+        return cache[key] && cache[key] == dependencyAccess(this, dependency);
+      });
 
       if (!cached) {
         dependencies.map(dependency => {

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -3803,6 +3803,16 @@ export function cachedComputedFrom(...rest) {
     return value;
   };
 
+  const dependencyKey = dependency => {
+    let key;
+    if (typeof dependency === "string") {
+      key = dependency;
+    } else {
+      key = dependency.name;
+    }
+    return key;
+  };
+
   return function (target, key, descriptor) {
     const _descriptor = descriptor.get;
     const dependencies = rest;
@@ -3810,32 +3820,23 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function () {
-
       const cached = dependencies.reduce((cached, dependency) => {
-        let key;
-        if (typeof dependency === "string") {
-          key = dependency;
-        } else {
-          key = dependency.name;
-        }
+        const key = dependencyKey(dependency);
         return cached && cache[key] == dependencyAccess(this, dependency);
       }, true);
 
       if (!cached) {
         dependencies.map(dependency => {
-          let key;
-          if (typeof dependency === "string") {
-            key = dependency;
-          } else {
-            key = dependency.name;
-          }
+          const key = dependencyKey(dependency);
           return cache[key] = dependencyAccess(this, dependency);
         });
         store = _descriptor.call(this);
       }
+
       return store;
     };
     descriptor.get.dependencies = rest;
+
     return descriptor;
   };
 }

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -3790,6 +3790,50 @@ export function computedFrom(...rest) {
   };
 }
 
+export function cachedComputedFrom(...rest) {
+  const dependencyAccess = (object, dependency) => {
+    let value;
+
+    if (typeof dependency === "string") {
+      value = dependency.split('.').reduce((subjObject, subdependency) => subjObject[subdependency], object);
+    } else {
+      let scope = { bindingContext: object, overrideContext: createOverrideContext(object) };
+      value = dependency.evaluate(scope, null);
+    }
+    return value;
+  };
+
+  return function (target, key, descriptor) {
+    const _descriptor = descriptor.get;
+    const dependencies = rest;
+    let store;
+    const cache = {};
+
+    descriptor.get = function () {
+
+      const cached = dependencies.reduce((cached, dependency) => {
+        return cached && cache[dependency] == dependencyAccess(this, dependency);
+      }, true);
+
+      if (!cached) {
+        dependencies.map(dependency => {
+          let key;
+          if (typeof dependency === "string") {
+            key = dependency;
+          } else {
+            key = dependency.name;
+          }
+          return cache[key] = dependencyAccess(this, dependency);
+        });
+        store = _descriptor.call(this);
+      }
+      return store;
+    };
+    descriptor.get.dependencies = rest;
+    return descriptor;
+  };
+}
+
 export let ComputedExpression = class ComputedExpression extends Expression {
   constructor(name, dependencies) {
     super();

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -3812,7 +3812,13 @@ export function cachedComputedFrom(...rest) {
     descriptor.get = function () {
 
       const cached = dependencies.reduce((cached, dependency) => {
-        return cached && cache[dependency] == dependencyAccess(this, dependency);
+        let key;
+        if (typeof dependency === "string") {
+          key = dependency;
+        } else {
+          key = dependency.name;
+        }
+        return cached && cache[key] == dependencyAccess(this, dependency);
       }, true);
 
       if (!cached) {

--- a/dist/system/aurelia-binding.d.ts
+++ b/dist/system/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -4324,7 +4324,13 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
             var _this26 = this;
 
             var cached = dependencies.reduce(function (cached, dependency) {
-              return cached && cache[dependency] == dependencyAccess(_this26, dependency);
+              var key = void 0;
+              if (typeof dependency === "string") {
+                key = dependency;
+              } else {
+                key = dependency.name;
+              }
+              return cached && cache[key] == dependencyAccess(_this26, dependency);
             }, true);
 
             if (!cached) {

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -4314,6 +4314,16 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
           return value;
         };
 
+        var dependencyKey = function dependencyKey(dependency) {
+          var key = void 0;
+          if (typeof dependency === "string") {
+            key = dependency;
+          } else {
+            key = dependency.name;
+          }
+          return key;
+        };
+
         return function (target, key, descriptor) {
           var _descriptor = descriptor.get;
           var dependencies = rest;
@@ -4324,30 +4334,22 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
             var _this26 = this;
 
             var cached = dependencies.reduce(function (cached, dependency) {
-              var key = void 0;
-              if (typeof dependency === "string") {
-                key = dependency;
-              } else {
-                key = dependency.name;
-              }
+              var key = dependencyKey(dependency);
               return cached && cache[key] == dependencyAccess(_this26, dependency);
             }, true);
 
             if (!cached) {
               dependencies.map(function (dependency) {
-                var key = void 0;
-                if (typeof dependency === "string") {
-                  key = dependency;
-                } else {
-                  key = dependency.name;
-                }
+                var key = dependencyKey(dependency);
                 return cache[key] = dependencyAccess(_this26, dependency);
               });
               store = _descriptor.call(this);
             }
+
             return store;
           };
           descriptor.get.dependencies = rest;
+
           return descriptor;
         };
       }

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -4333,10 +4333,10 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
           descriptor.get = function () {
             var _this26 = this;
 
-            var cached = dependencies.reduce(function (cached, dependency) {
+            var cached = dependencies.every(function (dependency) {
               var key = dependencyKey(dependency);
-              return cached && cache[key] == dependencyAccess(_this26, dependency);
-            }, true);
+              return cache[key] && cache[key] == dependencyAccess(_this26, dependency);
+            });
 
             if (!cached) {
               dependencies.map(function (dependency) {

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -4295,18 +4295,71 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
 
       _export('computedFrom', computedFrom);
 
+      function cachedComputedFrom() {
+        for (var _len2 = arguments.length, rest = Array(_len2), _key2 = 0; _key2 < _len2; _key2++) {
+          rest[_key2] = arguments[_key2];
+        }
+
+        var dependencyAccess = function dependencyAccess(object, dependency) {
+          var value = void 0;
+
+          if (typeof dependency === "string") {
+            value = dependency.split('.').reduce(function (subjObject, subdependency) {
+              return subjObject[subdependency];
+            }, object);
+          } else {
+            var scope = { bindingContext: object, overrideContext: createOverrideContext(object) };
+            value = dependency.evaluate(scope, null);
+          }
+          return value;
+        };
+
+        return function (target, key, descriptor) {
+          var _descriptor = descriptor.get;
+          var dependencies = rest;
+          var store = void 0;
+          var cache = {};
+
+          descriptor.get = function () {
+            var _this26 = this;
+
+            var cached = dependencies.reduce(function (cached, dependency) {
+              return cached && cache[dependency] == dependencyAccess(_this26, dependency);
+            }, true);
+
+            if (!cached) {
+              dependencies.map(function (dependency) {
+                var key = void 0;
+                if (typeof dependency === "string") {
+                  key = dependency;
+                } else {
+                  key = dependency.name;
+                }
+                return cache[key] = dependencyAccess(_this26, dependency);
+              });
+              store = _descriptor.call(this);
+            }
+            return store;
+          };
+          descriptor.get.dependencies = rest;
+          return descriptor;
+        };
+      }
+
+      _export('cachedComputedFrom', cachedComputedFrom);
+
       _export('ComputedExpression', ComputedExpression = function (_Expression19) {
         _inherits(ComputedExpression, _Expression19);
 
         function ComputedExpression(name, dependencies) {
           
 
-          var _this26 = _possibleConstructorReturn(this, _Expression19.call(this));
+          var _this27 = _possibleConstructorReturn(this, _Expression19.call(this));
 
-          _this26.name = name;
-          _this26.dependencies = dependencies;
-          _this26.isAssignable = true;
-          return _this26;
+          _this27.name = name;
+          _this27.dependencies = dependencies;
+          _this27.isAssignable = true;
+          return _this27;
         }
 
         ComputedExpression.prototype.evaluate = function evaluate(scope, lookupFunctions) {
@@ -4949,7 +5002,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
         };
 
         Call.prototype.bind = function bind(source) {
-          var _this27 = this;
+          var _this28 = this;
 
           if (this.isBound) {
             if (this.source === source) {
@@ -4964,7 +5017,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
             this.sourceExpression.bind(this, source, this.lookupFunctions);
           }
           this.targetProperty.setValue(function ($event) {
-            return _this27.callSource($event);
+            return _this28.callSource($event);
           });
         };
 
@@ -5113,7 +5166,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
         };
 
         Listener.prototype.bind = function bind(source) {
-          var _this28 = this;
+          var _this29 = this;
 
           if (this.isBound) {
             if (this.source === source) {
@@ -5128,7 +5181,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
             this.sourceExpression.bind(this, source, this.lookupFunctions);
           }
           this._disposeListener = this.eventManager.addEventListener(this.target, this.targetEvent, function (event) {
-            return _this28.callSource(event);
+            return _this29.callSource(event);
           }, this.delegate);
         };
 
@@ -5254,11 +5307,11 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
         };
 
         BindingEngine.prototype.propertyObserver = function propertyObserver(obj, propertyName) {
-          var _this29 = this;
+          var _this30 = this;
 
           return {
             subscribe: function subscribe(callback) {
-              var observer = _this29.observerLocator.getObserver(obj, propertyName);
+              var observer = _this30.observerLocator.getObserver(obj, propertyName);
               observer.subscribe(callback);
               return {
                 dispose: function dispose() {
@@ -5270,17 +5323,17 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
         };
 
         BindingEngine.prototype.collectionObserver = function collectionObserver(collection) {
-          var _this30 = this;
+          var _this31 = this;
 
           return {
             subscribe: function subscribe(callback) {
               var observer = void 0;
               if (collection instanceof Array) {
-                observer = _this30.observerLocator.getArrayObserver(collection);
+                observer = _this31.observerLocator.getArrayObserver(collection);
               } else if (collection instanceof Map) {
-                observer = _this30.observerLocator.getMapObserver(collection);
+                observer = _this31.observerLocator.getMapObserver(collection);
               } else if (collection instanceof Set) {
-                observer = _this30.observerLocator.getSetObserver(collection);
+                observer = _this31.observerLocator.getSetObserver(collection);
               } else {
                 throw new Error('collection must be an instance of Array, Map or Set.');
               }

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -385,6 +385,13 @@ declare module 'aurelia-binding' {
   export function computedFrom(...propertyNames: string[]): any;
 
  /**
+  * Decorator: Indicates that the decorated property is computed from other properties and implements temporary caching for
+  * repeated fast access while dependencies remain unchanged.
+  * @param propertyNames The names of the properties the decorated property is computed from.  Simple property names, not expressions.
+  */
+  export function cachedComputedFrom(...propertyNames: string[]): any;
+
+ /**
   * Decorator: Indicates that the decorated class is a value converter.
   * @param name The name of the value converter.
   */
@@ -411,7 +418,7 @@ declare module 'aurelia-binding' {
    * An internal API used by Aurelia's array observation components.
    */
   export function mergeSplice(splices: any, index: number, removed: any, addedCount: number): any;
-  
+
   /**
   * Decorator: Specifies that a property is observable.
   * @param targetOrConfig The name of the property, or a configuration object.

--- a/src/computed-observation.js
+++ b/src/computed-observation.js
@@ -49,10 +49,10 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function() {
-      const cached = dependencies.reduce((cached, dependency) => {
+      const cached = dependencies.every((dependency) => {
         const key = dependencyKey(dependency);
-        return cached && cache[key] == dependencyAccess(this,dependency) ;
-      }, true);
+        return cache[key] && cache[key] == dependencyAccess(this,dependency) ;
+      });
 
       if (!cached) {
         dependencies.map((dependency) => {

--- a/src/computed-observation.js
+++ b/src/computed-observation.js
@@ -32,6 +32,16 @@ export function cachedComputedFrom(...rest) {
     return value;
   };
 
+  const dependencyKey = (dependency) => {
+    let key;
+    if (typeof dependency === "string") {
+      key = dependency;
+    } else {
+      key = dependency.name;
+    }
+    return key;
+  };
+
   return function(target, key, descriptor) {
     const _descriptor = descriptor.get;
     const dependencies = rest;
@@ -39,32 +49,23 @@ export function cachedComputedFrom(...rest) {
     const cache = {};
 
     descriptor.get = function() {
-
       const cached = dependencies.reduce((cached, dependency) => {
-        let key;
-        if (typeof dependency === "string") {
-          key = dependency;
-        } else {
-          key = dependency.name;
-        }
+        const key = dependencyKey(dependency);
         return cached && cache[key] == dependencyAccess(this,dependency) ;
       }, true);
 
       if (!cached) {
         dependencies.map((dependency) => {
-          let key;
-          if (typeof dependency === "string") {
-            key = dependency;
-          } else {
-            key = dependency.name;
-          }
+          const key = dependencyKey(dependency);
           return cache[key] = dependencyAccess(this,dependency);
         });
         store = _descriptor.call(this);
       }
+
       return store;
     };
     descriptor.get.dependencies = rest;
+
     return descriptor;
   };
 }

--- a/src/computed-observation.js
+++ b/src/computed-observation.js
@@ -18,6 +18,51 @@ export function computedFrom(...rest) {
   };
 }
 
+
+export function cachedComputedFrom(...rest) {
+  const dependencyAccess = (object, dependency) => {
+    let value;
+
+    if (typeof dependency === "string") {
+      value = dependency.split('.').reduce((subjObject, subdependency) => subjObject[subdependency], object);
+    } else {
+      let scope = { bindingContext: object, overrideContext: createOverrideContext(object) };
+      value = dependency.evaluate(scope, null);
+    }
+    return value;
+  };
+
+  return function(target, key, descriptor) {
+    const _descriptor = descriptor.get;
+    const dependencies = rest;
+    let store;
+    const cache = {};
+
+    descriptor.get = function() {
+
+      const cached = dependencies.reduce((cached, dependency) => {
+        return cached && cache[dependency] == dependencyAccess(this,dependency) ;
+      }, true);
+
+      if (!cached) {
+        dependencies.map((dependency) => {
+          let key;
+          if (typeof dependency === "string") {
+            key = dependency;
+          } else {
+            key = dependency.name;
+          }
+          return cache[key] = dependencyAccess(this,dependency);
+        });
+        store = _descriptor.call(this);
+      }
+      return store;
+    };
+    descriptor.get.dependencies = rest;
+    return descriptor;
+  };
+}
+
 export class ComputedExpression extends Expression {
   constructor(name, dependencies) {
     super();

--- a/src/computed-observation.js
+++ b/src/computed-observation.js
@@ -41,7 +41,13 @@ export function cachedComputedFrom(...rest) {
     descriptor.get = function() {
 
       const cached = dependencies.reduce((cached, dependency) => {
-        return cached && cache[dependency] == dependencyAccess(this,dependency) ;
+        let key;
+        if (typeof dependency === "string") {
+          key = dependency;
+        } else {
+          key = dependency.name;
+        }
+        return cached && cache[key] == dependencyAccess(this,dependency) ;
       }, true);
 
       if (!cached) {

--- a/test/computed-observation.spec.js
+++ b/test/computed-observation.spec.js
@@ -66,7 +66,7 @@ describe('createComputedObserver', () => {
     constructor() {
       this._bar = null;
     }
-  @computedFrom('_bar');
+    @computedFrom('_bar')
     get bar() {
       return this._bar;
     }
@@ -220,14 +220,30 @@ describe('createCachedComputedObserver', () => {
     person.obj.lastName = 'Dough';
 
     expect(person.fullerName).toBe("chineke Jon Dough");
+    expect(person.fullerName).toBe("chineke Jon Dough");
+    expect(person.fullerName).toBe("chineke Jon Dough");
 
     setTimeout(() => {
       expect(spy.calls.count()).toEqual(1);
+
+      person.obj.lastName = 'Doughy';
+      expect(person.fullerName).toBe("chineke Jon Doughy");
+
+      person.obj.lastName = 'Dough';
       expect(person.fullerName).toBe("chineke Jon Dough");
+
+      person.obj.lastName = 'Doughy';
+      expect(person.fullerName).toBe("chineke Jon Doughy");
+
+      expect(person.fullerName).toBe("chineke Jon Doughy");
+      expect(person.fullerName).toBe("chineke Jon Doughy");
+      expect(person.fullerName).toBe("chineke Jon Doughy");
+
       setTimeout(() => {
-        expect(spy.calls.count()).toEqual(1);
+        expect(spy.calls.count()).toEqual(4);
         done();
       }, 0);
+      done();
     }, 0);
 
   });

--- a/test/computed-observation.spec.js
+++ b/test/computed-observation.spec.js
@@ -2,6 +2,7 @@ import './setup';
 import {
   declarePropertyDependencies,
   computedFrom,
+  cachedComputedFrom,
   hasDeclaredDependencies
 } from '../src/computed-observation';
 import {ExpressionObserver} from '../src/expression-observer';
@@ -65,7 +66,7 @@ describe('createComputedObserver', () => {
     constructor() {
       this._bar = null;
     }
-    @computedFrom('_bar');
+  @computedFrom('_bar');
     get bar() {
       return this._bar;
     }
@@ -122,4 +123,113 @@ describe('createComputedObserver', () => {
       }, 0);
     }, 0);
   });
+});
+
+describe('createCachedComputedObserver', () => {
+  var person, observer, locator;
+
+  class Person {
+    constructor() {
+      this.obj = { firstName: 'John', lastName: 'Doe' };
+    }
+
+    @cachedComputedFrom('obj.firstName', 'obj.lastName')
+    get fullName() {
+      return `${this.obj.firstName} ${this.obj.lastName}`;
+    }
+
+    @cachedComputedFrom('fullName')
+    get fullerName() {
+      let fuller  = this.intermediateFunction();
+      return `${fuller} ${this.fullName}`;
+    }
+
+    intermediateFunction () {
+      return 'chineke';
+    }
+  }
+
+  class Foo {
+    constructor() {
+      this._bar = null;
+    }
+    @cachedComputedFrom('_bar')
+    get bar() {
+      return this._bar;
+    }
+    set bar(newValue) {
+      this._bar = newValue;
+    }
+  }
+
+
+  beforeAll(() => {
+    locator = createObserverLocator();
+    person = new Person();
+    observer = locator.getObserver(person, 'fullName');
+  });
+
+  it('should have declared dependencies after observer is created', () => {
+    expect(hasDeclaredDependencies(Object.getPropertyDescriptor(person, 'fullName'))).toBe(true);
+  });
+
+  it('should be an ExpressionObserver', () => {
+    expect(observer instanceof ExpressionObserver).toBe(true);
+  });
+
+  it('gets the value', () => {
+    expect(observer.getValue()).toBe(person.fullName);
+  });
+
+  it('sets the value', () => {
+    var foo = new Foo(),
+        fooObserver = locator.getObserver(foo, 'bar');
+
+    fooObserver.setValue(7);
+
+    expect(foo.bar).toBe(7);
+  });
+
+  it('notifies when value changes', done => {
+    var callback = callback = jasmine.createSpy('callback'),
+        oldValue = observer.getValue();
+
+    expect(observer.oldValue).toBeUndefined();
+    observer.subscribe(callback);
+    expect(observer.oldValue).toBe(observer.getValue());
+    person.obj.lastName = 'Dough';
+    setTimeout(() => {
+      expect(callback).toHaveBeenCalledWith(person.fullName, oldValue);
+      oldValue = observer.getValue();
+      person.obj.firstName = 'Jon';
+      setTimeout(() => {
+        expect(callback).toHaveBeenCalledWith(person.fullName, oldValue);
+        observer.unsubscribe(callback);
+        expect(observer.oldValue).toBeUndefined();
+        done();
+      }, 0);
+    }, 0);
+  });
+
+  it('returns cached value if dependencies are unchanged', done => {
+
+    let spy = spyOn(Person.prototype, "intermediateFunction").and.callThrough();
+
+    person = new Person();
+    person.obj.firstName = 'Jon';
+    person.obj.lastName = 'Dough';
+
+    expect(person.fullerName).toBe("chineke Jon Dough");
+
+    setTimeout(() => {
+      expect(spy.calls.count()).toEqual(1);
+      expect(person.fullerName).toBe("chineke Jon Dough");
+      setTimeout(() => {
+        expect(spy.calls.count()).toEqual(1);
+        done();
+      }, 0);
+    }, 0);
+
+  });
+
 });


### PR DESCRIPTION
cachedComputedFrom is just a caching-enabled version of computedFrom.
cachedComputedFrom implements temporary caching for repeated fast access to the computed property while it's dependencies remain unchanged.

I did some profiling and cachedComputedFrom was more performant where it needed to be, i.e. when the the computed property is the same if it's dependencies remain unchanged.
