### PR TITLE
Respect non-enumerable properties

### DIFF
--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -96,7 +96,8 @@ export class SetterObserver {
 
     if (!Reflect.defineProperty(this.obj, this.propertyName, {
       configurable: true,
-      enumerable: true,
+      enumerable: this.propertyName in this.obj ?
+          this.obj.propertyIsEnumerable(this.propertyName) : true,
       get: this.getValue.bind(this),
       set: this.setValue.bind(this)
     })) {

--- a/test/observer-locator.spec.js
+++ b/test/observer-locator.spec.js
@@ -53,6 +53,24 @@ describe('ObserverLocator', () => {
     expect(Logger.prototype.warn).toHaveBeenCalledWith('Cannot observe property \'bar\' of object', obj);
   });
 
+  it('respects the enumerability in the SetterObserver', () => {
+    var obj = {};
+    Object.defineProperties(obj, {
+      'foo': {
+        configurable: true,
+        enumerable: true
+      },
+      'bar': {
+        configurable: true,
+        enumerable: false
+      }
+    });
+    ['foo', 'bar', 'baz'].forEach(prop => {
+      locator.getObserver(obj, prop).convertProperty();
+    });
+    expect(Object.keys(obj)).toEqual(['foo', 'baz']);
+  });
+
   it('uses ValueAttributeObserver for element value attributes', () => {
     var obj = createElement('<input />'),
         observer = locator.getObserver(obj, 'value');


### PR DESCRIPTION
When creating a property like this:
```
Reflect.defineProperty(obj, 'foo', {
  configurable: true,
  enumerable: false, // <-- non-enumerable
  set: setter,
  get: getter
});
```
the property observer will add its own setter and getter (which is a good thing), but also sets the `enumerable` setting to `true`.
This PR makes the observer respect the existing setting.