### PR TITLE
feat(ViewEngineHooksResource): Enable registering ViewEngineHooks by convention

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -58,7 +58,8 @@ gulp.task('build-index', function(){
     'name-expression.js',
     'binding-engine.js',
     'set-observation.js',
-    'decorator-observable.js'
+    'decorator-observable.js',
+    'view-engine-hooks-resource.js'
     ].map(function(file){
       return paths.root + file;
   });

--- a/dist/amd/aurelia-binding.d.ts
+++ b/dist/amd/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/dist/amd/aurelia-binding.js
+++ b/dist/amd/aurelia-binding.js
@@ -4,7 +4,7 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
   Object.defineProperty(exports, "__esModule", {
     value: true
   });
-  exports.getSetObserver = exports.BindingEngine = exports.NameExpression = exports.Listener = exports.ListenerExpression = exports.BindingBehaviorResource = exports.ValueConverterResource = exports.Call = exports.CallExpression = exports.Binding = exports.BindingExpression = exports.ObjectObservationAdapter = exports.ObserverLocator = exports.SVGAnalyzer = exports.presentationAttributes = exports.presentationElements = exports.elements = exports.ComputedExpression = exports.ClassObserver = exports.SelectValueObserver = exports.CheckedObserver = exports.ValueAttributeObserver = exports.StyleObserver = exports.DataAttributeObserver = exports.dataAttributeAccessor = exports.XLinkAttributeObserver = exports.SetterObserver = exports.PrimitiveObserver = exports.propertyAccessor = exports.DirtyCheckProperty = exports.DirtyChecker = exports.EventManager = exports.getMapObserver = exports.ParserImplementation = exports.Parser = exports.Scanner = exports.Lexer = exports.Token = exports.bindingMode = exports.ExpressionCloner = exports.Unparser = exports.LiteralObject = exports.LiteralArray = exports.LiteralString = exports.LiteralPrimitive = exports.PrefixNot = exports.Binary = exports.CallFunction = exports.CallMember = exports.CallScope = exports.AccessKeyed = exports.AccessMember = exports.AccessScope = exports.AccessThis = exports.Conditional = exports.Assign = exports.ValueConverter = exports.BindingBehavior = exports.Chain = exports.Expression = exports.getArrayObserver = exports.CollectionLengthObserver = exports.ModifyCollectionObserver = exports.ExpressionObserver = exports.sourceContext = undefined;
+  exports.ViewEngineHooksResource = exports.getSetObserver = exports.BindingEngine = exports.NameExpression = exports.Listener = exports.ListenerExpression = exports.BindingBehaviorResource = exports.ValueConverterResource = exports.Call = exports.CallExpression = exports.Binding = exports.BindingExpression = exports.ObjectObservationAdapter = exports.ObserverLocator = exports.SVGAnalyzer = exports.presentationAttributes = exports.presentationElements = exports.elements = exports.ComputedExpression = exports.ClassObserver = exports.SelectValueObserver = exports.CheckedObserver = exports.ValueAttributeObserver = exports.StyleObserver = exports.DataAttributeObserver = exports.dataAttributeAccessor = exports.XLinkAttributeObserver = exports.SetterObserver = exports.PrimitiveObserver = exports.propertyAccessor = exports.DirtyCheckProperty = exports.DirtyChecker = exports.EventManager = exports.getMapObserver = exports.ParserImplementation = exports.Parser = exports.Scanner = exports.Lexer = exports.Token = exports.bindingMode = exports.ExpressionCloner = exports.Unparser = exports.LiteralObject = exports.LiteralArray = exports.LiteralString = exports.LiteralPrimitive = exports.PrefixNot = exports.Binary = exports.CallFunction = exports.CallMember = exports.CallScope = exports.AccessKeyed = exports.AccessMember = exports.AccessScope = exports.AccessThis = exports.Conditional = exports.Assign = exports.ValueConverter = exports.BindingBehavior = exports.Chain = exports.Expression = exports.getArrayObserver = exports.CollectionLengthObserver = exports.ModifyCollectionObserver = exports.ExpressionObserver = exports.sourceContext = undefined;
   exports.camelCase = camelCase;
   exports.createOverrideContext = createOverrideContext;
   exports.getContextFor = getContextFor;
@@ -24,6 +24,7 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
   exports.valueConverter = valueConverter;
   exports.bindingBehavior = bindingBehavior;
   exports.observable = observable;
+  exports.viewEngineHooks = viewEngineHooks;
 
   var LogManager = _interopRequireWildcard(_aureliaLogging);
 
@@ -5321,5 +5322,35 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
     }
 
     return deco;
+  }
+
+  var ViewEngineHooksResource = exports.ViewEngineHooksResource = function () {
+    function ViewEngineHooksResource() {
+      
+    }
+
+    ViewEngineHooksResource.prototype.initialize = function initialize(container, target) {
+      this.instance = container.get(target);
+    };
+
+    ViewEngineHooksResource.prototype.register = function register(registry, name) {
+      registry.registerViewEngineHooks(this.instance);
+    };
+
+    ViewEngineHooksResource.prototype.load = function load(container, target) {};
+
+    ViewEngineHooksResource.convention = function convention(name) {
+      if (name.endsWith('ViewEngineHooks')) {
+        return new ViewEngineHooksResource();
+      }
+    };
+
+    return ViewEngineHooksResource;
+  }();
+
+  function viewEngineHooks(target) {
+    return function (target) {
+      _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, new ViewEngineHooksResource(), target);
+    };
   }
 });

--- a/dist/aurelia-binding.d.ts
+++ b/dist/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/dist/aurelia-binding.js
+++ b/dist/aurelia-binding.js
@@ -5054,3 +5054,29 @@ export function observable(targetOrConfig, key, descriptor) {
 
   return deco;
 }
+
+export class ViewEngineHooksResource {
+  constructor() {}
+
+  initialize(container, target) {
+    this.instance = container.get(target);
+  }
+
+  register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  }
+
+  load(container, target) {}
+  
+  static convention(name) { // eslint-disable-line
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  }
+}
+
+export function viewEngineHooks(target) { // eslint-disable-line
+  return function(target) {
+    metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+  };
+}

--- a/dist/commonjs/aurelia-binding.d.ts
+++ b/dist/commonjs/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getSetObserver = exports.BindingEngine = exports.NameExpression = exports.Listener = exports.ListenerExpression = exports.BindingBehaviorResource = exports.ValueConverterResource = exports.Call = exports.CallExpression = exports.Binding = exports.BindingExpression = exports.ObjectObservationAdapter = exports.ObserverLocator = exports.SVGAnalyzer = exports.presentationAttributes = exports.presentationElements = exports.elements = exports.ComputedExpression = exports.ClassObserver = exports.SelectValueObserver = exports.CheckedObserver = exports.ValueAttributeObserver = exports.StyleObserver = exports.DataAttributeObserver = exports.dataAttributeAccessor = exports.XLinkAttributeObserver = exports.SetterObserver = exports.PrimitiveObserver = exports.propertyAccessor = exports.DirtyCheckProperty = exports.DirtyChecker = exports.EventManager = exports.getMapObserver = exports.ParserImplementation = exports.Parser = exports.Scanner = exports.Lexer = exports.Token = exports.bindingMode = exports.ExpressionCloner = exports.Unparser = exports.LiteralObject = exports.LiteralArray = exports.LiteralString = exports.LiteralPrimitive = exports.PrefixNot = exports.Binary = exports.CallFunction = exports.CallMember = exports.CallScope = exports.AccessKeyed = exports.AccessMember = exports.AccessScope = exports.AccessThis = exports.Conditional = exports.Assign = exports.ValueConverter = exports.BindingBehavior = exports.Chain = exports.Expression = exports.getArrayObserver = exports.CollectionLengthObserver = exports.ModifyCollectionObserver = exports.ExpressionObserver = exports.sourceContext = undefined;
+exports.ViewEngineHooksResource = exports.getSetObserver = exports.BindingEngine = exports.NameExpression = exports.Listener = exports.ListenerExpression = exports.BindingBehaviorResource = exports.ValueConverterResource = exports.Call = exports.CallExpression = exports.Binding = exports.BindingExpression = exports.ObjectObservationAdapter = exports.ObserverLocator = exports.SVGAnalyzer = exports.presentationAttributes = exports.presentationElements = exports.elements = exports.ComputedExpression = exports.ClassObserver = exports.SelectValueObserver = exports.CheckedObserver = exports.ValueAttributeObserver = exports.StyleObserver = exports.DataAttributeObserver = exports.dataAttributeAccessor = exports.XLinkAttributeObserver = exports.SetterObserver = exports.PrimitiveObserver = exports.propertyAccessor = exports.DirtyCheckProperty = exports.DirtyChecker = exports.EventManager = exports.getMapObserver = exports.ParserImplementation = exports.Parser = exports.Scanner = exports.Lexer = exports.Token = exports.bindingMode = exports.ExpressionCloner = exports.Unparser = exports.LiteralObject = exports.LiteralArray = exports.LiteralString = exports.LiteralPrimitive = exports.PrefixNot = exports.Binary = exports.CallFunction = exports.CallMember = exports.CallScope = exports.AccessKeyed = exports.AccessMember = exports.AccessScope = exports.AccessThis = exports.Conditional = exports.Assign = exports.ValueConverter = exports.BindingBehavior = exports.Chain = exports.Expression = exports.getArrayObserver = exports.CollectionLengthObserver = exports.ModifyCollectionObserver = exports.ExpressionObserver = exports.sourceContext = undefined;
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
@@ -30,6 +30,7 @@ exports.createComputedObserver = createComputedObserver;
 exports.valueConverter = valueConverter;
 exports.bindingBehavior = bindingBehavior;
 exports.observable = observable;
+exports.viewEngineHooks = viewEngineHooks;
 
 var _aureliaLogging = require('aurelia-logging');
 
@@ -5274,4 +5275,34 @@ function observable(targetOrConfig, key, descriptor) {
   }
 
   return deco;
+}
+
+var ViewEngineHooksResource = exports.ViewEngineHooksResource = function () {
+  function ViewEngineHooksResource() {
+    
+  }
+
+  ViewEngineHooksResource.prototype.initialize = function initialize(container, target) {
+    this.instance = container.get(target);
+  };
+
+  ViewEngineHooksResource.prototype.register = function register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  };
+
+  ViewEngineHooksResource.prototype.load = function load(container, target) {};
+
+  ViewEngineHooksResource.convention = function convention(name) {
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  };
+
+  return ViewEngineHooksResource;
+}();
+
+function viewEngineHooks(target) {
+  return function (target) {
+    _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, new ViewEngineHooksResource(), target);
+  };
 }

--- a/dist/es2015/aurelia-binding.d.ts
+++ b/dist/es2015/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -4816,3 +4816,29 @@ export function observable(targetOrConfig, key, descriptor) {
 
   return deco;
 }
+
+export let ViewEngineHooksResource = class ViewEngineHooksResource {
+  constructor() {}
+
+  initialize(container, target) {
+    this.instance = container.get(target);
+  }
+
+  register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  }
+
+  load(container, target) {}
+
+  static convention(name) {
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  }
+};
+
+export function viewEngineHooks(target) {
+  return function (target) {
+    metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+  };
+}

--- a/dist/system/aurelia-binding.d.ts
+++ b/dist/system/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -1,7 +1,9 @@
 'use strict';
 
 System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aurelia-metadata'], function (_export, _context) {
-  var LogManager, PLATFORM, DOM, TaskQueue, metadata, _typeof, _createClass, _dec, _dec2, _class, _dec3, _class2, _dec4, _class3, _dec5, _class5, _dec6, _class7, _dec7, _class8, _dec8, _class9, _dec9, _class10, _class11, _temp, _dec10, _class12, _class13, _temp2, map, sourceContext, slotNames, versionSlotNames, i, bindings, minimumImmediate, frameBudget, isFlushRequested, immediate, arrayPool1, arrayPool2, poolUtilization, ExpressionObserver, EDIT_LEAVE, EDIT_UPDATE, EDIT_ADD, EDIT_DELETE, arraySplice, ModifyCollectionObserver, CollectionLengthObserver, pop, push, reverse, shift, sort, splice, unshift, ModifyArrayObserver, Expression, Chain, BindingBehavior, ValueConverter, Assign, Conditional, AccessThis, AccessScope, AccessMember, AccessKeyed, CallScope, CallMember, CallFunction, Binary, PrefixNot, LiteralPrimitive, LiteralString, LiteralArray, LiteralObject, evalListCache, Unparser, ExpressionCloner, bindingMode, Token, Lexer, Scanner, OPERATORS, $EOF, $TAB, $LF, $VTAB, $FF, $CR, $SPACE, $BANG, $DQ, $$, $PERCENT, $AMPERSAND, $SQ, $LPAREN, $RPAREN, $STAR, $PLUS, $COMMA, $MINUS, $PERIOD, $SLASH, $COLON, $SEMICOLON, $LT, $EQ, $GT, $QUESTION, $0, $9, $A, $E, $Z, $LBRACKET, $BACKSLASH, $RBRACKET, $CARET, $_, $a, $e, $f, $n, $r, $t, $u, $v, $z, $LBRACE, $BAR, $RBRACE, $NBSP, EOF, Parser, ParserImplementation, mapProto, ModifyMapObserver, DelegateHandlerEntry, DefaultEventStrategy, EventManager, DirtyChecker, DirtyCheckProperty, logger, propertyAccessor, PrimitiveObserver, SetterObserver, XLinkAttributeObserver, dataAttributeAccessor, DataAttributeObserver, StyleObserver, ValueAttributeObserver, checkedArrayContext, checkedValueContext, CheckedObserver, selectArrayContext, SelectValueObserver, ClassObserver, ComputedExpression, elements, presentationElements, presentationAttributes, SVGAnalyzer, ObserverLocator, ObjectObservationAdapter, BindingExpression, targetContext, Binding, CallExpression, Call, ValueConverterResource, BindingBehaviorResource, ListenerExpression, Listener, NameExpression, NameBinder, LookupFunctions, BindingEngine, setProto, ModifySetObserver;
+  "use strict";
+
+  var LogManager, PLATFORM, DOM, TaskQueue, metadata, _typeof, _createClass, _dec, _dec2, _class, _dec3, _class2, _dec4, _class3, _dec5, _class5, _dec6, _class7, _dec7, _class8, _dec8, _class9, _dec9, _class10, _class11, _temp, _dec10, _class12, _class13, _temp2, map, sourceContext, slotNames, versionSlotNames, i, bindings, minimumImmediate, frameBudget, isFlushRequested, immediate, arrayPool1, arrayPool2, poolUtilization, ExpressionObserver, EDIT_LEAVE, EDIT_UPDATE, EDIT_ADD, EDIT_DELETE, arraySplice, ModifyCollectionObserver, CollectionLengthObserver, pop, push, reverse, shift, sort, splice, unshift, ModifyArrayObserver, Expression, Chain, BindingBehavior, ValueConverter, Assign, Conditional, AccessThis, AccessScope, AccessMember, AccessKeyed, CallScope, CallMember, CallFunction, Binary, PrefixNot, LiteralPrimitive, LiteralString, LiteralArray, LiteralObject, evalListCache, Unparser, ExpressionCloner, bindingMode, Token, Lexer, Scanner, OPERATORS, $EOF, $TAB, $LF, $VTAB, $FF, $CR, $SPACE, $BANG, $DQ, $$, $PERCENT, $AMPERSAND, $SQ, $LPAREN, $RPAREN, $STAR, $PLUS, $COMMA, $MINUS, $PERIOD, $SLASH, $COLON, $SEMICOLON, $LT, $EQ, $GT, $QUESTION, $0, $9, $A, $E, $Z, $LBRACKET, $BACKSLASH, $RBRACKET, $CARET, $_, $a, $e, $f, $n, $r, $t, $u, $v, $z, $LBRACE, $BAR, $RBRACE, $NBSP, EOF, Parser, ParserImplementation, mapProto, ModifyMapObserver, DelegateHandlerEntry, DefaultEventStrategy, EventManager, DirtyChecker, DirtyCheckProperty, logger, propertyAccessor, PrimitiveObserver, SetterObserver, XLinkAttributeObserver, dataAttributeAccessor, DataAttributeObserver, StyleObserver, ValueAttributeObserver, checkedArrayContext, checkedValueContext, CheckedObserver, selectArrayContext, SelectValueObserver, ClassObserver, ComputedExpression, elements, presentationElements, presentationAttributes, SVGAnalyzer, ObserverLocator, ObjectObservationAdapter, BindingExpression, targetContext, Binding, CallExpression, Call, ValueConverterResource, BindingBehaviorResource, ListenerExpression, Listener, NameExpression, NameBinder, LookupFunctions, BindingEngine, setProto, ModifySetObserver, ViewEngineHooksResource;
 
   function _possibleConstructorReturn(self, call) {
     if (!self) {
@@ -5434,6 +5436,40 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
       }
 
       _export('observable', observable);
+
+      _export('ViewEngineHooksResource', ViewEngineHooksResource = function () {
+        function ViewEngineHooksResource() {
+          
+        }
+
+        ViewEngineHooksResource.prototype.initialize = function initialize(container, target) {
+          this.instance = container.get(target);
+        };
+
+        ViewEngineHooksResource.prototype.register = function register(registry, name) {
+          registry.registerViewEngineHooks(this.instance);
+        };
+
+        ViewEngineHooksResource.prototype.load = function load(container, target) {};
+
+        ViewEngineHooksResource.convention = function convention(name) {
+          if (name.endsWith('ViewEngineHooks')) {
+            return new ViewEngineHooksResource();
+          }
+        };
+
+        return ViewEngineHooksResource;
+      }());
+
+      _export('ViewEngineHooksResource', ViewEngineHooksResource);
+
+      function viewEngineHooks(target) {
+        return function (target) {
+          metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+        };
+      }
+
+      _export('viewEngineHooks', viewEngineHooks);
     }
   };
 });

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -71,6 +71,16 @@ declare module 'aurelia-binding' {
     register(registry: any, name: string): void;
   }
 
+  /** 
+   * A ViewEngineHooks resource.
+   */
+  export class ViewEngineHooksResource {
+    static convention(name: string): ViewEngineHooksResource;
+    constructor();
+    initialize(container: Container, target: any): void;
+    register(registry: any, name: string): void;
+  }
+
   /**
    * Decorator: Adds efficient subscription management methods to the decorated class's prototype.
    */
@@ -396,6 +406,11 @@ declare module 'aurelia-binding' {
   */
   export function bindingBehavior(name: string): any;
 
+  /**
+   * Decorator: Registers the decorated class as a ViewEngineHook.
+   */
+  export function viewEngineHooks(): any;
+ 
   /**
    * A context used when invoking a binding's callable API to notify
    * the binding that the context is a "source update".

--- a/src/view-engine-hooks-resource.js
+++ b/src/view-engine-hooks-resource.js
@@ -1,0 +1,28 @@
+import {camelCase} from './camel-case';
+import {metadata} from 'aurelia-metadata';
+
+export class ViewEngineHooksResource {
+  constructor() {}
+
+  initialize(container, target) {
+    this.instance = container.get(target);
+  }
+
+  register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  }
+
+  load(container, target) {}
+  
+  static convention(name) { // eslint-disable-line
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  }
+}
+
+export function viewEngineHooks(target) { // eslint-disable-line
+  return function(target) {
+    metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+  };
+}

--- a/test/view-engine-hooks-resource.spec.js
+++ b/test/view-engine-hooks-resource.spec.js
@@ -1,0 +1,10 @@
+import './setup';
+import {ViewEngineHooksResource} from '../src/view-engine-hooks-resource';
+
+describe('ViewEngineHooksResource', () => {
+  it('uses ends with ViewEngineHooks convention', () => {
+    expect(BindingBehaviorResource.convention('FooViewEngineHooks')).toBeDefined();
+    expect(BindingBehaviorResource.convention('FooViewEngineHooks') instanceof BindingBehaviorResource).toBe(true);
+    expect(BindingBehaviorResource.convention('FooBar')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
A ViewEngineHooks object can now be registered by either
 - Creating a {Name}ViewEngineHooks class that implements ViewEngineHooks
 - Decorating a class that implements ViewEngineHooks with @viewEngineHooks

and
 - Registering that class with the view via a <require> tag
 - Configuring the class as a globalResource