### PR TITLE
fix(property-observation): now detects no change when both oldValue and newValue are NaN

### DIFF
--- a/src/property-observation.js
+++ b/src/property-observation.js
@@ -57,7 +57,7 @@ export class SetterObserver {
   setterValue(newValue) {
     let oldValue = this.currentValue;
 
-    if (oldValue !== newValue) {
+    if (oldValue !== newValue && !(Number.isNaN(oldValue) && Number.isNaN(newValue))) {
       if (!this.queued) {
         this.oldValue = oldValue;
         this.queued = true;

--- a/test/binding-engine.spec.js
+++ b/test/binding-engine.spec.js
@@ -51,6 +51,27 @@ describe('bindingEngine', () => {
     });
   });
 
+  it('detects in property change that NaN is equal to NaN', done => {
+    let obj = { foo: NaN };
+    let callback = jasmine.createSpy('callback');
+    let subscription = bindingEngine.propertyObserver(obj, 'foo').subscribe(callback);
+    obj.foo = NaN;
+    setTimeout(() => {
+      expect(callback).not.toHaveBeenCalled();
+      obj.foo = 123;
+      setTimeout(() => {
+        expect(callback).toHaveBeenCalledWith(123, NaN);
+        subscription.dispose();
+        callback.calls.reset();
+        obj.foo = 123;
+        setTimeout(() => {
+          expect(callback).not.toHaveBeenCalled();
+          done();
+        });
+      });
+    });
+  });
+
   it('observes and unobserves array changes', done => {
     let obj = [];
     let callback = jasmine.createSpy('callback');


### PR DESCRIPTION
In Javascript the expression "NaN === NaN" always resolves to false.
Aurelia uses the expression "oldValue !== newValue" to detect if a property has changed and change-handlers should be called.
This fails if both oldValue and newValue are NaN.
Therefore an extra comparison was added: "!( isNaN(oldValue) && isNaN(newValue) )".