### PR TITLE
Suggest changing logging <div> to <output> tag

### DIFF
--- a/doc/example/binding-binding-behaviors/custom/app.html
+++ b/doc/example/binding-binding-behaviors/custom/app.html
@@ -29,9 +29,9 @@
     </div>
 
     <!-- logging -->
-    <div style="max-height: 300px; overflow-y: auto">
+    <output style="max-height: 300px; overflow-y: auto">
       <div repeat.for="x of intercepted" css="color: ${x.color}">
         Intercepted the binding's [${x.method}] method.  The value is "${x.value}"
       </div>
-    </div>
+    </output>
 </template>


### PR DESCRIPTION
The output tag is more semantic for what we're trying to achieve here and it will allow me to write more general and reusable css.