### PR TITLE
(aurelia-binding.d.ts): remove TypeScript 2.0 syntax

### DIFF
--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -411,8 +411,8 @@ export declare class Conditional extends Expression {
  * A literal primitive (null, undefined, number, boolean).
  */
 export declare class LiteralPrimitive extends Expression {
-  value: null|undefined|number|boolean;
-  constructor(value: null|undefined|number|boolean);
+  value: number|boolean;
+  constructor(value: number|boolean);
 }
 
 /**


### PR DESCRIPTION
The null and undefined types are a feature of TypeScript 2.0, which hasn't been released yet.

See #487.