### PR TITLE
fix(StyleObserver): enable !important override, remove regex parsing

### DIFF
--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -53,7 +53,6 @@ export class StyleObserver {
     this.propertyName = propertyName;
 
     this.styles = null;
-    this.version = 0;
   }
 
   getValue() {
@@ -61,46 +60,38 @@ export class StyleObserver {
   }
 
   setValue(newValue) {
-    let styles = this.styles || {};
+    let styles = '';
     let style;
-    let version = this.version;
 
     if (newValue !== null && newValue !== undefined) {
       if (newValue instanceof Object) {
+        styles = '';
         for (style in newValue) {
           if (newValue.hasOwnProperty(style)) {
-            styles[style] = version;
-            this.element.style[style] = newValue[style];
+            styles += `${style}: ${newValue[style]};`;
           }
         }
       } else if (newValue.length) {
-        let rx = /\s*([\w\-]+)\s*:\s*((?:(?:[\w\-]+\(\s*(?:"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[\w\-]+\(\s*(?:^"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^\)]*)\),?|[^\)]*)\),?|"(?:\\"|[^"])*"|'(?:\\'|[^'])*'|[^;]*),?\s*)+);?/g;
-        let pair;
-        while ((pair = rx.exec(newValue)) !== null) {
-          style = pair[1];
-          if ( !style ) { continue; }
+        styles = newValue;
+      }
+    }
 
-          styles[style] = version;
-          this.element.style[style] = pair[2];
+    let el = document.createElement('div');
+    el.style.cssText = styles;
+    styles = el.style;
+
+    if ( this.styles ) {
+      for (let i = 0, e = this.styles.length; i < e; ++i) {
+        style = this.styles[i];
+        if ( !styles[style] ) {
+          this.element.style[style] = '';
         }
       }
     }
 
+    this.element.style.cssText += styles.cssText;
+
     this.styles = styles;
-    this.version += 1;
-
-    if (version === 0) {
-      return;
-    }
-
-    version -= 1;
-    for (style in styles) {
-      if (!styles.hasOwnProperty(style) || styles[style] !== version) {
-        continue;
-      }
-
-      this.element.style[style] = '';
-    }
   }
 
   subscribe() {

--- a/test/element-observation.spec.js
+++ b/test/element-observation.spec.js
@@ -155,49 +155,68 @@ describe('element observation', () => {
       expect(observer instanceof StyleObserver).toBe(true);
       expect(() => observer.subscribe(() => {})).toThrow(new Error('Observation of a "DIV" element\'s "' + attrs[i] + '" property is not supported.'));
 
+      el.style.borderStyle = 'solid';
+      expect(el.style.borderStyle).toBe('solid');
+
       observer.setValue(' 	  width : 30px;height:20px; background-color	: red;background-image: url("http://aurelia.io/test.png"); 	 ');
-      //expect(observer.getValue()).toBe('width: 30px; height: 20px; background-image: url("http://aurelia.io/test.png"); background-color: red;');
       expect(el.style.height).toBe('20px');
       expect(el.style.width).toBe('30px');
       expect(el.style.backgroundColor).toBe('red');
       expect(el.style.backgroundImage).toBe('url("http://aurelia.io/test.png")');
+      expect(el.style.borderStyle).toBe('solid');
 
       observer.setValue('');
       expect(el.style.height).toBe('');
       expect(el.style.width).toBe('');
       expect(el.style.backgroundColor).toBe('');
       expect(el.style.backgroundImage).toBe('');
+      expect(el.style.borderStyle).toBe('solid');
 
-      observer.setValue(` width : 25px ; background: url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=");`);
+      observer.setValue(` width : 25px ; background-image: url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=");`);
       expect(el.style.width).toBe('25px');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
 
       observer.setValue('');
       expect(el.style.width).toBe('');
       expect(el.style.background).toBe('');
 
-      observer.setValue(` width : 25px ; background: url('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&\\'()*+,;=');`);
+      observer.setValue(` width : 25px ; background-image: url('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&\\'()*+,;=');`);
       expect(el.style.width).toBe('25px');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
 
       observer.setValue('');
       expect(el.style.width).toBe('');
-      expect(el.style.background).toBe('');
+      expect(el.style.backgroundImage).toBe('');
 
-      observer.setValue(`    color : rgb( 255 , 255 , 255 ) ; background: url(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=);`);
+      observer.setValue(`    color : rgb( 255 , 255 , 255 ) ; background-image: url(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=);`);
       expect(el.style.color).toBe('rgb(255, 255, 255)');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=")`);
 
       observer.setValue('');
       expect(el.style.color).toBe('');
-      expect(el.style.background).toBe('');
+      expect(el.style.backgroundImage).toBe('');
 
-      observer.setValue(`background: url(data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7);`);
-      expect(el.style.background).toBe(`url("data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7")`);
+      observer.setValue(`background-image: url(data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7);`);
+      expect(el.style.backgroundImage).toBe(`url("data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7")`);
 
       observer.setValue('');
-      expect(el.style.width).toBe('');
+      expect(el.style.backgroundImage).toBe('');
+
+      observer.setValue('background-color: #000 !important;');
+      expect(el.style.backgroundColor).toBe('rgb(0, 0, 0)');
+
+      observer.setValue('');
       expect(el.style.background).toBe('');
+
+      observer.setValue('font-weight: bold !important');
+      expect(el.style.fontWeight).toBe('bold');
+      observer.setValue('font-weight: normal');
+      expect(el.style.fontWeight).toBe('bold');
+      observer.setValue('font-weight: normal !important');
+      expect(el.style.fontWeight).toBe('normal');
+
+      observer.setValue('');
+      expect(el.style.fontWeight).toBe('');
 
       observer.setValue({ width: '50px', height: '40px', 'background-color': 'blue', 'background-image': 'url("http://aurelia.io/test2.png")' });
       expect(el.style.height).toBe('40px');


### PR DESCRIPTION
No longer using regex to parse the styles. Enables setting a style with `!important` priority to override an existing `!important` style.

aurelia/templating-resources/issues/251