### PR TITLE
fix(StyleObserver): enable !important override

### DIFF
--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -60,6 +60,16 @@ export class StyleObserver {
     return this.element.style.cssText;
   }
 
+  _setProperty(style, value) {
+    let priority = '';
+
+    if (value.indexOf('!important') !== -1) {
+      priority = 'important';
+      value = value.replace('!important', '');
+    }
+    this.element.style.setProperty(style, value, priority);
+  }
+
   setValue(newValue) {
     let styles = this.styles || {};
     let style;
@@ -70,7 +80,7 @@ export class StyleObserver {
         for (style in newValue) {
           if (newValue.hasOwnProperty(style)) {
             styles[style] = version;
-            this.element.style[style] = newValue[style];
+            this._setProperty(style, newValue[style]);
           }
         }
       } else if (newValue.length) {
@@ -81,7 +91,7 @@ export class StyleObserver {
           if ( !style ) { continue; }
 
           styles[style] = version;
-          this.element.style[style] = pair[2];
+          this._setProperty(style, pair[2]);
         }
       }
     }
@@ -99,7 +109,7 @@ export class StyleObserver {
         continue;
       }
 
-      this.element.style[style] = '';
+      this.element.style.removeProperty(style);
     }
   }
 

--- a/test/element-observation.spec.js
+++ b/test/element-observation.spec.js
@@ -155,49 +155,66 @@ describe('element observation', () => {
       expect(observer instanceof StyleObserver).toBe(true);
       expect(() => observer.subscribe(() => {})).toThrow(new Error('Observation of a "DIV" element\'s "' + attrs[i] + '" property is not supported.'));
 
+      el.style.borderStyle = 'solid';
+      expect(el.style.borderStyle).toBe('solid');
+
       observer.setValue(' 	  width : 30px;height:20px; background-color	: red;background-image: url("http://aurelia.io/test.png"); 	 ');
-      //expect(observer.getValue()).toBe('width: 30px; height: 20px; background-image: url("http://aurelia.io/test.png"); background-color: red;');
       expect(el.style.height).toBe('20px');
       expect(el.style.width).toBe('30px');
       expect(el.style.backgroundColor).toBe('red');
       expect(el.style.backgroundImage).toBe('url("http://aurelia.io/test.png")');
+      expect(el.style.borderStyle).toBe('solid');
 
       observer.setValue('');
       expect(el.style.height).toBe('');
       expect(el.style.width).toBe('');
       expect(el.style.backgroundColor).toBe('');
       expect(el.style.backgroundImage).toBe('');
+      expect(el.style.borderStyle).toBe('solid');
 
-      observer.setValue(` width : 25px ; background: url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=");`);
+      observer.setValue(` width : 25px ; background-image: url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=");`);
       expect(el.style.width).toBe('25px');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
 
       observer.setValue('');
       expect(el.style.width).toBe('');
       expect(el.style.background).toBe('');
 
-      observer.setValue(` width : 25px ; background: url('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&\\'()*+,;=');`);
+      observer.setValue(` width : 25px ; background-image: url('abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&\\'()*+,;=');`);
       expect(el.style.width).toBe('25px');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&'()*+,;=")`);
 
       observer.setValue('');
       expect(el.style.width).toBe('');
-      expect(el.style.background).toBe('');
+      expect(el.style.backgroundImage).toBe('');
 
-      observer.setValue(`    color : rgb( 255 , 255 , 255 ) ; background: url(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=);`);
+      observer.setValue(`    color : rgb( 255 , 255 , 255 ) ; background-image: url(abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=);`);
       expect(el.style.color).toBe('rgb(255, 255, 255)');
-      expect(el.style.background).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=")`);
+      expect(el.style.backgroundImage).toBe(`url("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~:/?#[]%@!$&*+,;=")`);
 
       observer.setValue('');
       expect(el.style.color).toBe('');
-      expect(el.style.background).toBe('');
+      expect(el.style.backgroundImage).toBe('');
 
-      observer.setValue(`background: url(data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7);`);
-      expect(el.style.background).toBe(`url("data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7")`);
+      observer.setValue(`background-image: url(data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7);`);
+      expect(el.style.backgroundImage).toBe(`url("data:image/gif;base64,R0lGODh0o/XBs/fNl3/zy7//wA7")`);
 
       observer.setValue('');
-      expect(el.style.width).toBe('');
+      expect(el.style.backgroundImage).toBe('');
+
+      observer.setValue('background-color: #000 !important;');
+      expect(el.style.backgroundColor).toBe('rgb(0, 0, 0)');
+
+      observer.setValue('');
       expect(el.style.background).toBe('');
+
+      observer.setValue('width: 10px');
+      expect(el.style.width).toBe('10px');
+      observer.setValue('width: 15px !important');
+      expect(el.style.width).toBe('15px');
+
+      observer.setValue('');
+      expect(el.style.fontWeight).toBe('');
 
       observer.setValue({ width: '50px', height: '40px', 'background-color': 'blue', 'background-image': 'url("http://aurelia.io/test2.png")' });
       expect(el.style.height).toBe('40px');


### PR DESCRIPTION
Inline styles must use `!important` to overwrite `!important` stylesheet rules.

fixes aurelia/templating-resources/issues/251