### PR TITLE
Partial fix for #501

### DIFF
--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -23,9 +23,11 @@ export function observable(targetOrConfig: any, key: string, descriptor?: Proper
     } else {
       // there is no descriptor if the target was a field, 
       // or if the decorator was applied to a class.
-      descriptor = {
-        enumerable: true  // if the target was a field, it was enumerable
-      };
+      descriptor = { };
+    }
+    // make the accessor enumerable by default, as fields are enumerable
+    if (!('enumerable' in descriptor)) {
+      descriptor.enumerable = true;
     }
 
     // we're adding a getter and setter which means the property descriptor

--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -1,7 +1,8 @@
 export function observable(targetOrConfig: any, key: string, descriptor?: PropertyDescriptor) {
   function deco(target, key, descriptor, config) { // eslint-disable-line no-shadow
     // class decorator?
-    if (key === undefined) {
+    const isClassDecorator = key === undefined;
+    if (isClassDecorator) {
       target = target.prototype;
       key = typeof config === 'string' ? config : config.name;
     }
@@ -42,7 +43,12 @@ export function observable(targetOrConfig: any, key: string, descriptor?: Proper
     // dependencies. This is the equivalent of "@computedFrom(...)".
     descriptor.get.dependencies = [innerPropertyName];
 
-    return descriptor;
+    if (isClassDecorator) {
+      Reflect.defineProperty(target, key, descriptor); 
+    }
+    else {
+      return descriptor;
+    }
   }
 
   if (key === undefined) {

--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -21,9 +21,9 @@ export function observable(targetOrConfig: any, key: string, descriptor?: Proper
         target[innerPropertyName] = descriptor.initializer();
       }
     } else {
-      // there is no descriptor if the target was a field, 
+      // there is no descriptor if the target was a field in TS (although Babel provides one), 
       // or if the decorator was applied to a class.
-      descriptor = { };
+      descriptor = {};
     }
     // make the accessor enumerable by default, as fields are enumerable
     if (!('enumerable' in descriptor)) {

--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -42,7 +42,7 @@ export function observable(targetOrConfig: any, key: string, descriptor?: Proper
     // dependencies. This is the equivalent of "@computedFrom(...)".
     descriptor.get.dependencies = [innerPropertyName];
 
-    Reflect.defineProperty(target, key, descriptor);
+    return descriptor;
   }
 
   if (key === undefined) {

--- a/src/decorator-observable.js
+++ b/src/decorator-observable.js
@@ -21,7 +21,11 @@ export function observable(targetOrConfig: any, key: string, descriptor?: Proper
         target[innerPropertyName] = descriptor.initializer();
       }
     } else {
-      descriptor = {};
+      // there is no descriptor if the target was a field, 
+      // or if the decorator was applied to a class.
+      descriptor = {
+        enumerable: true  // if the target was a field, it was enumerable
+      };
     }
 
     // we're adding a getter and setter which means the property descriptor

--- a/test/decorator-observable.spec.js
+++ b/test/decorator-observable.spec.js
@@ -113,6 +113,6 @@ describe('observable decorator', () => {
     const instance = new class {
       @observable value;
     };
-    expect(instance.isPropertyEnumerable('value')).toBe(true);
+    expect(instance.propertyIsEnumerable('value')).toBe(true);
   });
 });

--- a/test/decorator-observable.spec.js
+++ b/test/decorator-observable.spec.js
@@ -108,4 +108,11 @@ describe('observable decorator', () => {
     instance.value = newValue;
     expect(instance.customHandler).toHaveBeenCalledWith(newValue, oldValue, 'value');
   });
+  
+  it('should create an enumerable accessor', () => {
+    const instance = new class {
+      @observable value;
+    };
+    expect(instance.isPropertyEnumerable('value')).toBe(true);
+  });
 });

--- a/test/decorator-observable.spec.js
+++ b/test/decorator-observable.spec.js
@@ -113,6 +113,10 @@ describe('observable decorator', () => {
     const instance = new class {
       @observable value;
     };
-    expect(instance.propertyIsEnumerable('value')).toBe(true);
+    const keys = [];
+    for (let p in instance) {
+      keys.push(p);
+    }
+    expect(keys).toContain('value');
   });
 });


### PR DESCRIPTION
Makes the decorator chainable by letting the system install the property and return the descriptor.
This doesn't change the observable implementation strategy (enumerable field, non-enumerable accessor, etc.)