### PR TITLE
fix(styleobserver): improper value check in if

### DIFF
--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -63,7 +63,7 @@ export class StyleObserver {
   _setProperty(style, value) {
     let priority = '';
 
-    if (value.indexOf && value.indexOf('!important') !== -1) {
+    if (value && value.indexOf('!important') !== -1) {
       priority = 'important';
       value = value.replace('!important', '');
     }

--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -63,7 +63,7 @@ export class StyleObserver {
   _setProperty(style, value) {
     let priority = '';
 
-    if (value && value.indexOf('!important') !== -1) {
+    if (typeof value !== typeof undefined && typeof value.indexOf !== typeof undefined && value.indexOf('!important') !== -1) {
       priority = 'important';
       value = value.replace('!important', '');
     }

--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -63,7 +63,7 @@ export class StyleObserver {
   _setProperty(style, value) {
     let priority = '';
 
-    if (typeof value !== typeof undefined && typeof value.indexOf !== typeof undefined && value.indexOf('!important') !== -1) {
+    if (value !== null && value !== undefined && typeof value.indexOf === 'function' && value.indexOf('!important') !== -1) {
       priority = 'important';
       value = value.replace('!important', '');
     }


### PR DESCRIPTION
The previous if statement check would break things if the value was undefined, as such, indexOf which was being checked for would not exist on an undefined/null value. The better check to do is just ensure that value exists as this seems to be a better way of handling this numeric edge case.