### PR TITLE
fix(StyleObserver): convert camelCase properties to kebab-case

### DIFF
--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -77,10 +77,13 @@ export class StyleObserver {
 
     if (newValue !== null && newValue !== undefined) {
       if (newValue instanceof Object) {
+        let value;
         for (style in newValue) {
           if (newValue.hasOwnProperty(style)) {
+            value = newValue[style];
+            style = style.replace(/([A-Z])/g, m => '-' + m.toLowerCase());
             styles[style] = version;
-            this._setProperty(style, newValue[style]);
+            this._setProperty(style, value);
           }
         }
       } else if (newValue.length) {

--- a/test/element-observation.spec.js
+++ b/test/element-observation.spec.js
@@ -225,7 +225,7 @@ describe('element observation', () => {
       observer.setValue('');
       expect(el.style.opacity).toBe('');
       
-      observer.setValue({ width: '50px', height: '40px', 'background-color': 'blue', 'background-image': 'url("http://aurelia.io/test2.png")' });
+      observer.setValue({ width: '50px', height: '40px', backgroundColor: 'blue', 'background-image': 'url("http://aurelia.io/test2.png")' });
       expect(el.style.height).toBe('40px');
       expect(el.style.width).toBe('50px');
       expect(el.style.backgroundColor).toBe('blue');


### PR DESCRIPTION
The property methods (`set|removeProperty`) don't recognize _camelCased_ names.

fixes #523 
