### PR TITLE
refactor(size): Unparser opt-out

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -16,7 +16,9 @@ export class Expression {
   }
 
   toString() {
-    return Unparser.unparse(this);
+    return typeof FEATURE_NO_UNPARSER === 'undefined' ? 
+      Unparser.unparse(this) :
+      super.toString();
   }
 }
 


### PR DESCRIPTION
Add a global free variable `FEATURE_NO_UNPARSER` that can be used to remove `Unparser` from the build.

`Unparser` is mainly a debugging feature that is not used by consumers of Aurelia. The only visible change when removing it is that calling `toString()` on an `Expression` returns `[object Object]` instead printing the AST back to a string.

Removing `Unparser` cuts approx. 2K of minified code.

**Caution**: `Unparser` is presently used by `aurelia-validation` and can't be removed from an application that uses it. See aurelia/validation#412.