### PR TITLE
Fix for Unhandled rejection TypeError: Cannot read property 'valueConverters' of undefined

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -187,7 +187,7 @@ export class Conditional extends Expression {
   }
 
   evaluate(scope, lookupFunctions) {
-    return (!!this.condition.evaluate(scope)) ? this.yes.evaluate(scope) : this.no.evaluate(scope);
+    return (!!this.condition.evaluate(scope, lookupFunctions)) ? this.yes.evaluate(scope, lookupFunctions) : this.no.evaluate(scope, lookupFunctions);
   }
 
   accept(visitor) {
@@ -451,15 +451,15 @@ export class Binary extends Expression {
   }
 
   evaluate(scope, lookupFunctions) {
-    let left = this.left.evaluate(scope);
+    let left = this.left.evaluate(scope, lookupFunctions);
 
     switch (this.operation) {
-    case '&&': return left && this.right.evaluate(scope);
-    case '||': return left || this.right.evaluate(scope);
+    case '&&': return left && this.right.evaluate(scope, lookupFunctions);
+    case '||': return left || this.right.evaluate(scope, lookupFunctions);
     // no default
     }
 
-    let right = this.right.evaluate(scope);
+    let right = this.right.evaluate(scope, lookupFunctions);
 
     switch (this.operation) {
     case '==' : return left == right; // eslint-disable-line eqeqeq
@@ -526,7 +526,7 @@ export class PrefixNot extends Expression {
   }
 
   evaluate(scope, lookupFunctions) {
-    return !this.expression.evaluate(scope);
+    return !this.expression.evaluate(scope, lookupFunctions);
   }
 
   accept(visitor) {


### PR DESCRIPTION
I am working on a project using i18n and ValidationController. In my translations file I wanted to be able to make a variable lowercase by using a ValueConverter:

"ERRORMESSAGES": {
        "required": "${$displayName} is required",
        "matches": "${$value} is not a valid ${$displayName| toLowercase }"
    }

Using this I got the following error:
Unhandled rejection TypeError: Cannot read property 'valueConverters' of undefined

I inspected the code in vendor-bundle.js and found the problem was in ast.js of aurelia-binding. After changing the code it worked well. Now, where possible, the parameter lookupFunctions is passed to the chained evaluate method.