### PR TITLE
feat(binding-expression): add improved error message to updateSource …

### DIFF
--- a/src/binding-expression.js
+++ b/src/binding-expression.js
@@ -40,11 +40,21 @@ export class Binding {
   }
 
   updateTarget(value) {
-    this.targetObserver.setValue(value, this.target, this.targetProperty);
+    try {
+      this.targetObserver.setValue(value, this.target, this.targetProperty);
+    } catch (e) {
+      throw new Error(
+        `aurelia-binding: Error encountered updating property ${this.targetProperty} of target ${this.target} to ${value} - ${e}`
+      );
+    }
   }
 
   updateSource(value) {
-    this.sourceExpression.assign(this.source, value, this.lookupFunctions);
+    try {
+      this.sourceExpression.assign(this.source, value, this.lookupFunctions);
+    } catch (e) {
+      throw new Error(`aurelia-binding: Error encountered setting value of source ${source} to ${value} - ${e}`);
+    }
   }
 
   call(context, newValue, oldValue) {


### PR DESCRIPTION
…and updateTarget

Added custom error messages to BindingExpression when updateSource() or updateTarget() fails.
These include information about what the source/target that was being set,
and what value it was being set to. Previously the underlying error was allowed to bubble to the top,
and valuable information about the context of the binding expression was not reported.