### PR TITLE
feat(Binding): fromView, toView

### DIFF
--- a/src/binding-expression.js
+++ b/src/binding-expression.js
@@ -89,20 +89,24 @@ export class Binding {
 
     let mode = this.mode;
     if (!this.targetObserver) {
-      let method = mode === bindingMode.twoWay ? 'getObserver' : 'getAccessor';
+      let method = mode === bindingMode.twoWay || mode === bindingMode.fromView ? 'getObserver' : 'getAccessor';
       this.targetObserver = this.observerLocator[method](this.target, this.targetProperty);
     }
 
     if ('bind' in this.targetObserver) {
       this.targetObserver.bind();
     }
-    let value = this.sourceExpression.evaluate(source, this.lookupFunctions);
-    this.updateTarget(value);
+    if (this.mode !== bindingMode.fromView) {
+      let value = this.sourceExpression.evaluate(source, this.lookupFunctions);
+      this.updateTarget(value);
+    }
 
     if (mode === bindingMode.oneWay) {
       enqueueBindingConnect(this);
     } else if (mode === bindingMode.twoWay) {
       this.sourceExpression.connect(this, source);
+      this.targetObserver.subscribe(targetContext, this);
+    } else if (mode === bindingMode.fromView) {
       this.targetObserver.subscribe(targetContext, this);
     }
   }

--- a/src/binding-mode.js
+++ b/src/binding-mode.js
@@ -1,5 +1,7 @@
 export const bindingMode = {
   oneTime: 0,
   oneWay: 1,
-  twoWay: 2
+  twoWay: 2,
+  toView: 1,
+  fromView: 3
 };


### PR DESCRIPTION
This PR addresses:  
  * *Add one-way-out binding* aurelia/templating-binding#33

Related:
  * aurelia/templating-binding#114

```js
bindingMode.fromView
bindingMode.toView // alias of bindingMode.oneWay
```

Usage: 

```html
<input value.from-view='message' />

<!-- or -->
<my-input input.from-view='message' />
```

Note:

  * It feel a bit Yoda when reading the view code
  * [Demo](https://gist.run/?id=7c1ff795122a6e0b9bfe31ba88be6d85)

Edit:
  * cc @EisenbergEffect @jdanyow @Vheissu 