### PR TITLE
refactor(EventManager): Support handle event

### DIFF
--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -39,7 +39,11 @@ function handleCapturedEvent(event) {
   }
   for (let i = orderedCallbacks.length - 1; i >= 0; i--) {
     let orderedCallback = orderedCallbacks[i];
-    orderedCallback(event);
+    if ('handleEvent' in orderedCallback) {
+      orderedCallback.handleEvent(event);
+    } else {
+      orderedCallback(event);
+    }
     if (event.propagationStopped) {
       break;
     }
@@ -82,7 +86,11 @@ function handleDelegatedEvent(event) {
           interceptStopPropagation(event);
           interceptInstalled = true;
         }
-        callback(event);
+        if ('handleEvent' in callback) {
+          callback.handleEvent(event);
+        } else {
+          callback(event);
+        }
       }
     }
 
@@ -274,8 +282,8 @@ export class EventManager {
     return null;
   }
 
-  addEventListener(target, targetEvent, callback, delegate) {
+  addEventListener(target, targetEvent, callbackOrListener, delegate) {
     return (this.eventStrategyLookup[targetEvent] || this.defaultEventStrategy)
-      .subscribe(target, targetEvent, callback, delegate);
+      .subscribe(target, targetEvent, callbackOrListener, delegate);
   }
 }

--- a/src/listener-expression.js
+++ b/src/listener-expression.js
@@ -45,6 +45,10 @@ export class Listener {
     return result;
   }
 
+  handleEvent(event) {
+    this.callSource(event);
+  }
+
   bind(source) {
     if (this.isBound) {
       if (this.source === source) {
@@ -61,7 +65,7 @@ export class Listener {
     this._disposeListener = this.eventManager.addEventListener(
       this.target,
       this.targetEvent,
-      event => this.callSource(event),
+      this,
       this.delegationStrategy);
   }
 

--- a/test/event-manager.spec.js
+++ b/test/event-manager.spec.js
@@ -142,7 +142,7 @@ describe('EventManager', () => {
       let stopDelegate = (event) => {
         event.stopPropagation();
         wasCalled = true;
-      }
+      };
       em.addEventListener(one, 'delegate', oneDelegate, true);
       em.addEventListener(three, 'delegate', stopDelegate, true);
 
@@ -151,6 +151,19 @@ describe('EventManager', () => {
 
       expect(wasCalled).toBeTruthy();
       expect(oneDelegate).not.toHaveBeenCalledWith(threeDelegateEvent);
+    });
+
+    it('calls handleEvent', () => {
+      let wasCalled = false;
+      let listener = {
+        handleEvent() {
+          wasCalled = true;
+        }
+      };
+      em.addEventListener(one, 'any', listener);
+
+      one.dispatchEvent(DOM.createCustomEvent('any'));
+      expect(wasCalled).toBe(true);
     });
   });
 });


### PR DESCRIPTION
This PR is aimed to address change in `Listener` proposed in #604 , to use the instance as listener in `bind` instead of creating a new arrow function.

In my local, test 'connects 100 bindings immediately before queueing rest' in `connect-queue.spec.js` breaks as it only flushes around 90 - 91 in queueMicroTask. I'm not sure why.