### PR TITLE
feat(computedFrom): allow usage on method

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -360,8 +360,22 @@ export class CallScope extends Expression {
   }
 
   connect(binding, scope) {
-    let args = this.args;
-    let i = args.length;
+    const context = getContextFor(this.name, scope, this.ancestor);
+    const func = getFunction(context, this.name, false);
+    let i;
+    if (func !== null && func.dependencies !== undefined) {
+      const dependencies = func.dependencies;
+      i = dependencies.length;
+      while (i--) {
+        let dependency = dependencies[i];
+        if (typeof dependency === 'string') {
+          dependency = dependencies[i] = binding.observerLocator.parser.parse(dependency);
+        }
+        dependency.connect(binding, scope);
+      }
+    }
+    const args = this.args;
+    i = args.length;
     while (i--) {
       args[i].connect(binding, scope);
     }


### PR DESCRIPTION
This PR
  * follows [Jeremy's comment](https://github.com/aurelia/binding/issues/147#issuecomment-219471357)
  * enhances `computedFrom` decorator with error message when used on normal field
  * changes 1 test in call-scope spec, where it test binding shouldn't observeProperty.
  * addresses: parametrical computed / recursive observation (make methods observable) #147 

Usage similar to `computedFrom` on getter:

```js
class MyClass {
  @computedFrom('firstName', 'lastName')
  showWelcomeMessage(country) {
    return `${messages[country].hello} to ${this.firstName} ${this.lastName}`;
  }
}
```

  * [Demo](https://gist.run/?id=1ff1d80e45d5aa72f9b0c12de7047c06)

@EisenbergEffect @jdanyow  @davismj @jsobell