### PR TITLE
refactor(Element Observation): use handleEvent instead of bind

### DIFF
--- a/src/checked-observer.js
+++ b/src/checked-observer.js
@@ -111,9 +111,13 @@ export class CheckedObserver {
     this.callSubscribers(newValue, oldValue);
   }
 
+  handleEvent() {
+    this.synchronizeValue();
+  }
+
   subscribe(context, callable) {
     if (!this.hasSubscribers()) {
-      this.disposeHandler = this.handler.subscribe(this.element, this.synchronizeValue.bind(this, false));
+      this.disposeHandler = this.handler.subscribe(this.element, this);
     }
     this.addSubscriber(context, callable);
   }

--- a/src/element-observation.js
+++ b/src/element-observation.js
@@ -154,10 +154,14 @@ export class ValueAttributeObserver {
     this.oldValue = newValue;
   }
 
+  handleEvent() {
+    this.notify();
+  }
+
   subscribe(context, callable) {
     if (!this.hasSubscribers()) {
       this.oldValue = this.getValue();
-      this.disposeHandler = this.handler.subscribe(this.element, this.notify.bind(this));
+      this.disposeHandler = this.handler.subscribe(this.element, this);
     }
 
     this.addSubscriber(context, callable);

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -237,14 +237,14 @@ export class EventManager {
 
   createElementHandler(events) {
     return {
-      subscribe(target, callback) {
+      subscribe(target, callbackOrListener) {
         events.forEach(changeEvent => {
-          target.addEventListener(changeEvent, callback, false);
+          target.addEventListener(changeEvent, callbackOrListener, false);
         });
 
         return function() {
           events.forEach(changeEvent => {
-            target.removeEventListener(changeEvent, callback);
+            target.removeEventListener(changeEvent, callbackOrListener, false);
           });
         };
       }

--- a/src/select-value-observer.js
+++ b/src/select-value-observer.js
@@ -133,9 +133,13 @@ export class SelectValueObserver {
     this.callSubscribers(newValue, oldValue);
   }
 
+  handleEvent() {
+    this.synchronizeValue();
+  }
+
   subscribe(context, callable) {
     if (!this.hasSubscribers()) {
-      this.disposeHandler = this.handler.subscribe(this.element, this.synchronizeValue.bind(this, false));
+      this.disposeHandler = this.handler.subscribe(this.element, this);
     }
     this.addSubscriber(context, callable);
   }


### PR DESCRIPTION
This PR replaced

  * `checked-observer.js`, `select-observer.js`: `this.synchronizeValue.bind(this, false)` with `handleEvent() -> this.synchronizeValue()`
  * `ValueAttributeObserver`: this.notify.bind(this, false)` with `handleEvent() -> this.notify()`

I'm don't see bound parameter `false` used anywhere in `synchronizeValue` functions so I think it's safe to remove. Tests remain the same.
 