### PR TITLE
Add support for non-ASCII characters in identifiers

### DIFF
--- a/doc/article/en-US/binding-basics.md
+++ b/doc/article/en-US/binding-basics.md
@@ -163,3 +163,40 @@ The binding system makes several properties available for binding in your templa
 * `$last` - In a repeat template, is true if the item is the last item in the array.
 * `$even` - In a repeat template, is true if the item has an even numbered index.
 * `$odd` - In a repeat template, is true if the item has an odd numbered index.
+
+## [Non-ASCII Characters in Identifiers](aurelia-doc://section/9/version/1.0.0)
+
+When writing JavaScript, developers can choose from [a huge character set](https://codepoints.net/search?IDC=1) to name things:
+[This blog post](https://mathiasbynens.be/notes/javascript-identifiers-es6) elaborates on what makes a variable name valid in ES5 and ES6. In non-english domains, [it might even be best practice](https://www.webfactory.de/blog/ubiquitous-language-in-a-non-english-domain) to use actual business terms instead of translations in order to minimize any mental overhead when reading or writing code. 
+
+For performance reasons, Aurelia's binding parser only supports ASCII identifiers by default. Though, if you need to bind any fancy characters, you can globally configure the parser:
+
+<code-listing heading="Add non-ASCII identifier characters">
+  <source-code lang="ES 2015">
+    // boot.js
+    import {addIdentifierCharacters} from 'aurelia-binding';
+
+    export function configure(aurelia) {
+      addIdentifierCharacters("äöüÄÖÜß");
+      (...)
+    }
+  </source-code>
+  <source-code lang="ES 2016">
+    // boot.js
+    import {addIdentifierCharacters} from 'aurelia-binding';
+
+    export function configure(aurelia) {
+      addIdentifierCharacters("äöüÄÖÜß");
+      (...)
+    }
+  </source-code>
+  <source-code lang="TypeScript">
+    // boot.ts
+    import {addIdentifierCharacters} from 'aurelia-binding';
+
+    export async function configure(aurelia: Aurelia) {
+      addIdentifierCharacters("äöüÄÖÜß");
+      (...)
+    }
+  </source-code>
+</code-listing>

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -887,3 +887,9 @@ export declare function connectBindingToSignal(binding: Binding, name: string): 
  * @param name The signal associated with the binding(s) to refresh.
  */
 export declare function signalBindings(name: string): void;
+
+/**
+ * Globally adds support for parsing identifiers that contain any of the provided unicode characters.
+ * @param characters Any additional unicode characters to be supported for identifiers.
+ */
+export declare function addIdentifierCharacters(characters: string): void;

--- a/src/lexer.js
+++ b/src/lexer.js
@@ -292,6 +292,24 @@ export class Scanner {
   }
 }
 
+export function addIdentifierCharacters(chars) {
+  const codes = new Set();
+  for (var i = 0; i < chars.length; i++) {
+    codes.add(chars.codePointAt(i));
+  }
+
+  const _isIdentifierStart = isIdentifierStart;
+  const _isIdentifierPart = isIdentifierPart;
+
+  isIdentifierStart = function (code) {
+    return _isIdentifierStart(code) || codes.has(code);
+  }
+
+  isIdentifierPart = function (code) {
+    return _isIdentifierPart(code) || codes.has(code);
+  }
+}
+
 const OPERATORS = {
   'undefined': 1,
   'null': 1,
@@ -380,14 +398,14 @@ function isWhitespace(code) {
   return (code >= $TAB && code <= $SPACE) || (code === $NBSP);
 }
 
-function isIdentifierStart(code) {
+let isIdentifierStart = function(code) {
   return ($a <= code && code <= $z)
       || ($A <= code && code <= $Z)
       || (code === $_)
       || (code === $$);
 }
 
-function isIdentifierPart(code) {
+let isIdentifierPart = function(code) {
   return ($a <= code && code <= $z)
       || ($A <= code && code <= $Z)
       || ($0 <= code && code <= $9)

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -1,4 +1,5 @@
 import { Parser } from '../src/parser';
+import { addIdentifierCharacters } from '../src/lexer';
 import {
   LiteralString,
   LiteralPrimitive,
@@ -15,6 +16,8 @@ import {
   AccessAncestor,
   Assign
 } from '../src/ast';
+
+addIdentifierCharacters("äöüÄÖÜß");
 
 describe('Parser', () => {
   let parser;
@@ -99,6 +102,12 @@ describe('Parser', () => {
     let expression = parser.parse('foo');
     expect(expression instanceof AccessScope).toBe(true);
     expect(expression.name).toBe('foo');
+  });
+
+  it('parses additional identifier characters', () => {
+    let expression = parser.parse('öä');
+    expect(expression instanceof AccessScope).toBe(true);
+    expect(expression.name).toBe('öä');
   });
 
   it('parses AccessMember', () => {


### PR DESCRIPTION
Adds a static method `addIdentifierCharacters(string)` that can be used to modify how `isIdentifierStart/Part` work by adding a range of non-ASCII characters.

## Example

```typescript
// boot.ts
import { addIdentifierCharacters } from 'aurelia-binding';

export async function configure(aurelia: Aurelia) {
    addIdentifierCharacters("äöüÄÖÜß");
    (...)
}
```

This would allow binding expressions to use identifiers with any of those characters.

Fixes #640.
