### PR TITLE
feat(AST): Spread operator

### DIFF
--- a/src/lexer.js
+++ b/src/lexer.js
@@ -74,7 +74,11 @@ export class Scanner {
     switch (this.peek) {
     case $PERIOD:
       this.advance();
-      return isDigit(this.peek) ? this.scanNumber(start) : new Token(start, '.');
+      return isDigit(this.peek)
+        ? this.scanNumber(start)
+        : this.peek === $PERIOD
+          ? this.scanComplexOperator(start, $PERIOD, '..', '.')
+          : new Token(start, '.');
     case $LPAREN:
     case $RPAREN:
     case $LBRACE:
@@ -317,7 +321,8 @@ const OPERATORS = [
   '&',
   '|',
   '!',
-  '?'
+  '?',
+  '...'
 ];
 
 const $EOF = 0;

--- a/test/ast/call-member.spec.js
+++ b/test/ast/call-member.spec.js
@@ -1,4 +1,4 @@
-import {CallMember, AccessScope} from '../../src/ast';
+import {CallMember, AccessScope, Spread, LiteralPrimitive} from '../../src/ast';
 import {createScopeForTest} from '../../src/scope';
 
 describe('CallMember', () => {
@@ -25,5 +25,24 @@ describe('CallMember', () => {
     expect(() => expression.evaluate(createScopeForTest({ foo: {} }), null, mustEvaluate)).toThrow();
     expect(() => expression.evaluate(createScopeForTest({ foo: { bar: undefined } }), null, mustEvaluate)).toThrow();
     expect(() => expression.evaluate(createScopeForTest({ foo: { bar: null } }), null, mustEvaluate)).toThrow();
+  });
+
+  it('evaluates with rest parameters', () => {
+    let expression = new CallMember(
+      new AccessScope('foo', 0),
+      'bar',
+      [new Spread([new AccessScope('baz', 0), new LiteralPrimitive(5), new LiteralPrimitive(6)], true)]
+    );
+    let callResult;
+    let scope = createScopeForTest({
+      baz: 4,
+      foo: {
+        bar() {
+          callResult = [].slice.call(arguments);
+        }
+      }
+    });
+    expression.evaluate(scope);
+    expect(callResult.toString()).toBe('4,5,6');
   });
 });

--- a/test/ast/call-scope.spec.js
+++ b/test/ast/call-scope.spec.js
@@ -1,4 +1,4 @@
-import {CallScope, AccessScope} from '../../src/ast';
+import {CallScope, AccessScope, Spread, LiteralPrimitive} from '../../src/ast';
 import {createOverrideContext, createScopeForTest} from '../../src/scope';
 
 describe('CallScope', () => {
@@ -133,5 +133,22 @@ describe('CallScope', () => {
     expect(binding.observeProperty).not.toHaveBeenCalled();
     hello.connect(binding, scope);
     expect(binding.observeProperty).toHaveBeenCalledWith(scope.overrideContext.parentOverrideContext, 'arg');
+  });
+  
+  it('evaluates with rest parameters', () => {
+    let expression = new CallScope(
+      'bar',
+      [new Spread([new AccessScope('baz', 0), new LiteralPrimitive(5), new LiteralPrimitive(6)], true)],
+      0
+    );
+    let callResult;
+    let scope = createScopeForTest({
+      baz: 4,
+      bar() {
+        callResult = [].slice.call(arguments);
+      }
+    });
+    expression.evaluate(scope);
+    expect(callResult.toString()).toBe('4,5,6');
   });
 });


### PR DESCRIPTION
From feature request: #645 

### Supported syntax:

```html
<div>
  <!-- spread object literal -->
  <el prop.bind="{ ...{ one: 1 } }"></el>

  <!-- spread object accessed by key -->
  <el prop.bind="{ ...someObject }"></el>

  <!-- spread literal array -->
  <el prop.bind="[...[5,6,7, someValue]]"></el>

  <!-- spread array value accessed by key -->
  <el prop.bind="[...someArray]"></el>

  <!-- Call function with spread literal array -->
  <el prop.bind="getValue(...[5,6,7, someValue])"></el>

  <!-- Call function with spread accessed by key -->
  <el prop.bind="getValue(...someArguments)"></el>
</div>
```

### Observation strategy

* Only the accessed name is observed. Not every property of the object or array is observed automatically.

* [Demo](https://gist.run/?id=7722c6f3e9b302985e4ccf321bbd38f8)

@jdanyow What other tests should be in 😄 ?
@davismj @jdanyow Did I miss any usage of spread operator ?