### PR TITLE
perf(EventManager): enable dispose() pattern for addEventListener

### DIFF
--- a/dist/aurelia-binding.d.ts
+++ b/dist/aurelia-binding.d.ts
@@ -115,8 +115,10 @@ export declare class EventManager {
    * @param targetEvent Name of event to subscribe.
    * @param callback Event listener callback.
    * @param delegate True to use event delegation mechanism.
+   * @param diposable True to return a disposable object with dispose() method instead of a function
    * @returns function wich removes event listener.
    */
+  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy, disposable: true): Disposable;
   addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy): () => void;
 }
 
@@ -604,7 +606,7 @@ export declare interface NameExpression {
 /**
  * An expression AST visitor.
  */
-export interface ExpressionVisitor {}
+export interface ExpressionVisitor { }
 
 /**
  * Visits an expression AST and returns the string equivalent.
@@ -616,7 +618,7 @@ export class Unparser implements ExpressionVisitor {
 /**
  * Clones an expression AST.
  */
-export class ExpressionCloner implements ExpressionVisitor {}
+export class ExpressionCloner implements ExpressionVisitor { }
 
 /**
  * Provides the base class from which the classes that represent expression tree nodes are derived.

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -115,8 +115,10 @@ export declare class EventManager {
    * @param targetEvent Name of event to subscribe.
    * @param callback Event listener callback.
    * @param delegate True to use event delegation mechanism.
+   * @param diposable True to return a disposable object with dispose() method instead of a function
    * @returns function wich removes event listener.
    */
+  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy, disposable: true): Disposable;
   addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy): () => void;
 }
 

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -146,7 +146,6 @@ class EventHandler {
     this.target = target;
     this.targetEvent = targetEvent;
     this.callback = callback;
-    target.addEventListener(targetEvent, callback);
   }
 
   dispose() {
@@ -179,7 +178,7 @@ class DefaultEventStrategy {
       handlerEntry.increment();
       delegatedCallbacks[targetEvent] = callback;
 
-      if (disposable) {
+      if (disposable === true) {
         return new DelegationEntryHandler(handlerEntry, delegatedCallbacks, targetEvent);
       }
 
@@ -196,7 +195,7 @@ class DefaultEventStrategy {
       handlerEntry.increment();
       capturedCallbacks[targetEvent] = callback;
 
-      if (disposable) {
+      if (disposable === true) {
         return new DelegationEntryHandler(handlerEntry, capturedCallbacks, targetEvent);
       }
 
@@ -206,11 +205,11 @@ class DefaultEventStrategy {
       };
     }
 
-    if (disposable) {
+    target.addEventListener(targetEvent, callback);
+
+    if (disposable === true) {
       return new EventHandler(target, targetEvent, callback);
     }
-
-    target.addEventListener(targetEvent, callback);
 
     return function() {
       target.removeEventListener(targetEvent, callback);

--- a/src/listener-expression.js
+++ b/src/listener-expression.js
@@ -62,11 +62,13 @@ export class Listener {
     if (this.sourceExpression.bind) {
       this.sourceExpression.bind(this, source, this.lookupFunctions);
     }
-    this._disposeListener = this.eventManager.addEventListener(
+    this._handler = this.eventManager.addEventListener(
       this.target,
       this.targetEvent,
       this,
-      this.delegationStrategy);
+      this.delegationStrategy,
+      true
+    );
   }
 
   unbind() {
@@ -78,7 +80,7 @@ export class Listener {
       this.sourceExpression.unbind(this, this.source);
     }
     this.source = null;
-    this._disposeListener();
-    this._disposeListener = null;
+    this._handler.dispose();
+    this._handler = null;
   }
 }


### PR DESCRIPTION
This PR enable `dispose()` on `EventManager.addEventListener`, which will help reduce memory usage for aurelia app, regardless `delegate`, `capture` or `trigger` commands used, as it will not return an anonymous function, but a disposable object instead. Breaking change: no, only return `Disposable` when the fifth parameter is truthy, can be made `true` only to have stricter API.

@jdanyow @EisenbergEffect 