### PR TITLE
fix(EventSubscriber): do nothing if disposed

### DIFF
--- a/dist/aurelia-binding.d.ts
+++ b/dist/aurelia-binding.d.ts
@@ -118,8 +118,8 @@ export declare class EventManager {
    * @param diposable True to return a disposable object with dispose() method instead of a function
    * @returns function wich removes event listener.
    */
-  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy, disposable: true): Disposable;
-  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy): () => void;
+  addEventListener(target: Element, targetEvent: string, callback: EventListenerOrEventListenerObject, delegate: delegationStrategy, disposable: true): Disposable;
+  addEventListener(target: Element, targetEvent: string, callback: EventListenerOrEventListenerObject, delegate: delegationStrategy): () => void;
 }
 
 /**

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -118,8 +118,8 @@ export declare class EventManager {
    * @param diposable True to return a disposable object with dispose() method instead of a function
    * @returns function wich removes event listener.
    */
-  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy, disposable: true): Disposable;
-  addEventListener(target: Element, targetEvent: string, callback: (event: Event) => any, delegate: delegationStrategy): () => void;
+  addEventListener(target: EventTarget, targetEvent: string, callback: EventListenerOrEventListenerObject, delegate: delegationStrategy, disposable: true): Disposable;
+  addEventListener(target: EventTarget, targetEvent: string, callback: EventListenerOrEventListenerObject, delegate: delegationStrategy): () => void;
 }
 
 /**

--- a/src/event-manager.js
+++ b/src/event-manager.js
@@ -353,6 +353,10 @@ export class EventSubscriber {
   }
 
   dispose() {
+    if (this.element === null) {
+      // already disposed
+      return;
+    }
     let element = this.element;
     let callbackOrListener = this.handler;
     let events = this.events;


### PR DESCRIPTION
The `dispose()` should not be called more than once, but we can't control what binding behavior does, so put this check `element === null` in to avoid error