### PR TITLE
fix(SelectValueObserver): observe characterData mutation

### DIFF
--- a/src/select-value-observer.js
+++ b/src/select-value-observer.js
@@ -155,7 +155,7 @@ export class SelectValueObserver {
       this.synchronizeOptions();
       this.synchronizeValue();
     });
-    this.domObserver.observe(this.element, { childList: true, subtree: true });
+    this.domObserver.observe(this.element, { childList: true, subtree: true, characterData: true });
   }
 
   unbind() {


### PR DESCRIPTION
fixes #521
fixes #614
fixes aurelia/framework#717
fixes aurelia/templating-binding#124

----

recheck https://github.com/aurelia/i18n/issues/147

The existing mutation observer config works in situations where the number of `<option/>` elements changes, but fails where only the text content of those element change. Probably because of this, we didn't get a many reports from folks who use hierarchical select bindings.

all fixes demo at https://fix-select.bigopon.surge.sh/

@jdanyow @EisenbergEffect  