### PR TITLE
refactor(ast/parser): remove Chain

### DIFF
--- a/src/ast.js
+++ b/src/ast.js
@@ -4,7 +4,6 @@ import {connectBindingToSignal} from './signals';
 
 export class Expression {
   constructor() {
-    this.isChain = false;
     this.isAssignable = false;
   }
 
@@ -20,35 +19,6 @@ export class Expression {
     return typeof FEATURE_NO_UNPARSER === 'undefined' ?
       Unparser.unparse(this) :
       super.toString();
-  }
-}
-
-export class Chain extends Expression {
-  constructor(expressions) {
-    super();
-
-    this.expressions = expressions;
-    this.isChain = true;
-  }
-
-  evaluate(scope, lookupFunctions) {
-    let result;
-    let expressions = this.expressions;
-    let last;
-
-    for (let i = 0, length = expressions.length; i < length; ++i) {
-      last = expressions[i].evaluate(scope, lookupFunctions);
-
-      if (last !== null) {
-        result = last;
-      }
-    }
-
-    return result;
-  }
-
-  accept(visitor) {
-    return visitor.visitChain(this);
   }
 }
 

--- a/src/expression-cloner.js
+++ b/src/expression-cloner.js
@@ -1,5 +1,5 @@
 import {
-  Chain, ValueConverter, Assign, Conditional,
+  ValueConverter, Assign, Conditional,
   AccessThis, AccessScope, AccessMember, AccessKeyed,
   CallScope, CallFunction, CallMember,
   Unary, BindingBehavior, Binary,
@@ -14,10 +14,6 @@ export class ExpressionCloner {
       clonedArray[i] = array[i].accept(this);
     }
     return clonedArray;
-  }
-
-  visitChain(chain) {
-    return new Chain(this.cloneExpressionArray(chain.expressions));
   }
 
   visitBindingBehavior(behavior) {

--- a/src/unparser.js
+++ b/src/unparser.js
@@ -33,18 +33,6 @@ if (typeof FEATURE_NO_UNPARSER === 'undefined') {
       this.write(')');
     }
 
-    visitChain(chain) {
-      let expressions = chain.expressions;
-
-      for (let i = 0, length = expressions.length; i < length; ++i) {
-        if (i !== 0) {
-          this.write(';');
-        }
-
-        expressions[i].accept(this);
-      }
-    }
-
     visitBindingBehavior(behavior) {
       let args = behavior.args;
 

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -642,16 +642,13 @@ describe('Parser', () => {
 
       for (const expr of expressions) {
         it(expr, () => {
-          _verifyError(expr, 'Multiple expressions are not allowed');
+          _verifyError(expr, 'Unexpected character [;]');
         });
       }
     });
 
     describe('extra closing token', () => {
       const tests = [
-        { expr: ')', token: ')' },
-        { expr: ']', token: ']' },
-        { expr: '}', token: '}' },
         { expr: 'foo())', token: ')' },
         { expr: 'foo[x]]', token: ']' },
         { expr: '{foo}}', token: '}' }
@@ -660,6 +657,16 @@ describe('Parser', () => {
       for (const { expr, token } of tests) {
         it(expr, () => {
           _verifyError(expr, `Unconsumed token ${token}`);
+        });
+      }
+    });
+
+    describe('invalid expression start', () => {
+      const tests = [')', ']', '}', ''];
+
+      for (const expr of tests) {
+        it(expr, () => {
+          _verifyError(expr, `Invalid start of expression`);
         });
       }
     });


### PR DESCRIPTION
Chain isn't used anywhere and also can't be parsed from any valid expression. It appears to be a completely redundant expression.

Look only at the last commit

@bigopon