### PR TITLE
fix(parser): left-to-right associativity for nested binary expression…

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -106,7 +106,7 @@ export class ParserImplementation {
 
     while (this.tkn & T$BinaryOp) {
       const opToken = this.tkn;
-      if ((opToken & T$Precedence) < minPrecedence) {
+      if ((opToken & T$Precedence) <= minPrecedence) {
         break;
       }
       this.nextToken();

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -195,6 +195,20 @@ describe('Parser', () => {
       }
     });
 
+    describe('Binary left-to-right associativity', () => {
+      it('4/2*10', () => {
+        const expr = parser.parse('4/2*10');
+        const res = expr.evaluate({}, {});
+        expect(res).toBe(20);
+      });
+
+      it('4-2+10', () => {
+        const expr = parser.parse('4-2+10');
+        const res = expr.evaluate({}, {});
+        expect(res).toBe(12);
+      });
+    });
+
     describe('Binary operator precedence', () => {
       const x = [0, 1, 2, 3, 4, 5, 6, 7].map(i => new AccessScope(`x${i}`, 0));
       const b = (l, op, r) => new Binary(op, l, r);

--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -196,17 +196,30 @@ describe('Parser', () => {
     });
 
     describe('Binary left-to-right associativity', () => {
-      it('4/2*10', () => {
-        const expr = parser.parse('4/2*10');
-        const res = expr.evaluate({}, {});
-        expect(res).toBe(20);
-      });
+      const tests = [
+        { expr: '4/2*10', expected: 4/2*10 },
+        { expr: '4/2*10+1', expected: 4/2*10+1 },
+        { expr: '1+4/2+1', expected: 1+4/2+1 },
+        { expr: '1+4/2+1+1', expected: 1+4/2+1+1 },
+        { expr: '4/2*10', expected: 4/2*10 },
+        { expr: '4/2*10/2', expected: 4/2*10/2 },
+        { expr: '4/2*10*2', expected: 4/2*10*2 },
+        { expr: '4/2*10+2', expected: 4/2*10+2 },
+        { expr: '2/4/2*10', expected: 2/4/2*10 },
+        { expr: '2*4/2*10', expected: 2*4/2*10 },
+        { expr: '2+4/2*10', expected: 2+4/2*10 },
+        { expr: '2/4/2*10/2', expected: 2/4/2*10/2 },
+        { expr: '2*4/2*10*2', expected: 2*4/2*10*2 },
+        { expr: '2+4/2*10+2', expected: 2+4/2*10+2 }
+      ];
 
-      it('4-2+10', () => {
-        const expr = parser.parse('4-2+10');
-        const res = expr.evaluate({}, {});
-        expect(res).toBe(12);
-      });
+      for (const { expr, expected } of tests) {
+        it(`${expr} evaluates to ${expected}`, () => {
+          const parsed = parser.parse(expr);
+          const actual = parsed.evaluate({}, {});
+          expect(actual).toBe(expected);
+        });
+      }
     });
 
     describe('Binary operator precedence', () => {


### PR DESCRIPTION
Somehow I missed this one. Big oops. Fixes https://github.com/aurelia/binding/issues/586#issuecomment-399044403

@EisenbergEffect 