### PR TITLE
Feature: inverted (or arbitrary) checkbox

### DIFF
--- a/src/checked-observer.js
+++ b/src/checked-observer.js
@@ -56,24 +56,28 @@ export class CheckedObserver {
   }
 
   synchronizeElement() {
-    let value = this.value;
-    let element = this.element;
-    let elementValue = element.hasOwnProperty('model') ? element.model : element.value;
-    let isRadio = element.type === 'radio';
-    let matcher = element.matcher || ((a, b) => a === b);
+    const value = this.value;
+    const element = this.element;
+    const elementValue = element.hasOwnProperty('model') ? element.model : element.value;
+    const isRadio = element.type === 'radio';
+    const matcher = element.matcher || ((a, b) => a === b);
 
-    element.checked =
-      isRadio && !!matcher(value, elementValue)
-      || !isRadio && value === true
-      || !isRadio && Array.isArray(value) && value.findIndex(item => !!matcher(item, elementValue)) !== -1;
+    if (isRadio) {
+      element.checked = !!matcher(value, elementValue);
+    } else if (Array.isArray(value)) {
+      element.checked = value.findIndex(item => !!matcher(item, elementValue)) !== -1;
+    } else {
+      const checkedValue = element.hasOwnProperty('model') ? element.model : true;
+      element.checked = !!matcher(value, checkedValue);
+    }
   }
 
   synchronizeValue() {
     let value = this.value;
-    let element = this.element;
-    let elementValue = element.hasOwnProperty('model') ? element.model : element.value;
+    const element = this.element;
+    const elementValue = element.hasOwnProperty('model') ? element.model : element.value;
     let index;
-    let matcher = element.matcher || ((a, b) => a === b);
+    const matcher = element.matcher || ((a, b) => a === b);
 
     if (element.type === 'checkbox') {
       if (Array.isArray(value)) {
@@ -87,7 +91,10 @@ export class CheckedObserver {
         return;
       }
 
-      value = element.checked;
+
+      const checkedValue = element.hasOwnProperty('model') ? element.model : true;
+      const uncheckedValue = element.hasOwnProperty('modelUnchecked') ? element.modelUnchecked : false;
+      value = element.checked ? checkedValue : uncheckedValue;
     } else if (element.checked) {
       value = elementValue;
     } else {

--- a/test/checked-observer.spec.js
+++ b/test/checked-observer.spec.js
@@ -319,6 +319,62 @@ describe('CheckedObserver', () => {
     });
   });
 
+  describe('checkbox - custom values', () => {
+    var obj, el, binding;
+
+    beforeAll(() => {
+      obj = { color: 'red' };
+      el = createElement('<input type="checkbox" />');
+      document.body.appendChild(el);
+      el.model = 'red';
+      el.modelUnchecked = 'blue';
+      binding = getBinding(observerLocator, obj, 'color', el, 'checked', bindingMode.twoWay).binding;
+    });
+
+    it('binds', () => {
+      binding.bind(createScopeForTest(obj));
+      expect(el.checked).toBe(true);
+    });
+
+    it('responds to model change', done => {
+      obj.color = 'blue';
+      setTimeout(() => {
+        expect(el.checked).toBe(false);
+        done();
+      }, 0);
+    });
+
+    it('responds to element change', done => {
+      el.checked = false;
+      el.dispatchEvent(DOM.createCustomEvent('change'));
+      setTimeout(() => {
+        expect(obj.color).toBe('blue');
+        done();
+      }, 0);
+    });
+
+    it('notifies', () => {
+      let targetObserver = binding.targetObserver;
+      let spy = jasmine.createSpy('callback');
+      let oldValue = binding.targetObserver.getValue();
+      let newValue = 'red';
+      targetObserver.subscribe(spy);
+      targetObserver.setValue(newValue);
+      expect(spy).toHaveBeenCalledWith(newValue, oldValue);
+    });
+
+    it('unbinds', () => {
+      var targetObserver = binding.targetObserver;
+      spyOn(targetObserver, 'unbind').and.callThrough();
+      binding.unbind();
+      expect(targetObserver.unbind).toHaveBeenCalled();
+    });
+
+    afterAll(() => {
+      document.body.removeChild(el);
+    });
+  });
+
   describe('checkbox - late-bound value', () => {
     var obj, el, binding, binding2;
 

--- a/test/checked-observer.spec.js
+++ b/test/checked-observer.spec.js
@@ -263,6 +263,62 @@ describe('CheckedObserver', () => {
     });
   });
 
+  describe('checkbox - inverted boolean', () => {
+    var obj, el, binding;
+
+    beforeAll(() => {
+      obj = { checked: false };
+      el = createElement('<input type="checkbox" />');
+      document.body.appendChild(el);
+      el.model = false;
+      el.modelUnchecked = true;
+      binding = getBinding(observerLocator, obj, 'checked', el, 'checked', bindingMode.twoWay).binding;
+    });
+
+    it('binds', () => {
+      binding.bind(createScopeForTest(obj));
+      expect(el.checked).toBe(true);
+    });
+
+    it('responds to model change', done => {
+      obj.checked = true;
+      setTimeout(() => {
+        expect(el.checked).toBe(false);
+        done();
+      }, 0);
+    });
+
+    it('responds to element change', done => {
+      el.checked = true;
+      el.dispatchEvent(DOM.createCustomEvent('change'));
+      setTimeout(() => {
+        expect(obj.checked).toBe(false);
+        done();
+      }, 0);
+    });
+
+    it('notifies', () => {
+      let targetObserver = binding.targetObserver;
+      let spy = jasmine.createSpy('callback');
+      let oldValue = binding.targetObserver.getValue();
+      let newValue = true;
+      targetObserver.subscribe(spy);
+      targetObserver.setValue(newValue);
+      expect(spy).toHaveBeenCalledWith(newValue, oldValue);
+    });
+
+    it('unbinds', () => {
+      var targetObserver = binding.targetObserver;
+      spyOn(targetObserver, 'unbind').and.callThrough();
+      binding.unbind();
+      expect(targetObserver.unbind).toHaveBeenCalled();
+    });
+
+    afterAll(() => {
+      document.body.removeChild(el);
+    });
+  });
+
   describe('checkbox - late-bound value', () => {
     var obj, el, binding, binding2;
 


### PR DESCRIPTION
This adds the ability to use checkboxes with inverted boolean values, i.e., checked means `false` and unchecked means `true`: 

```Html
<input type="checkbox" checked.bind="something.inverted" model.bind="false" model-unchecked.bind="true">
```

But it’s not limited to inverting the checkbox. It can also be used to toggle between arbitrary values:
```Html
<input type="checkbox" checked.bind="displayMode" model.bind="'color'" model-unchecked.bind="'gray'"> Use color
```