### PR TITLE
fix(ArrayObservation): ensure patch applied only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "binding",
     "databinding"
   ],
+  "scripts": {
+    "test": "karma start"
+  },
   "homepage": "http://aurelia.io",
   "bugs": {
     "url": "https://github.com/aurelia/binding/issues"

--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-extend-native */
 import {ModifyCollectionObserver} from './collection-observation';
+import * as LogManager from 'aurelia-logging';
 
 const arrayProto = Array.prototype;
 const pop = arrayProto.pop;
@@ -12,7 +13,14 @@ const unshift = arrayProto.unshift;
 const arrayObserverKey = '__array_observer__';
 const patchedKey = '__au_patched__';
 
-if (!arrayProto[patchedKey]) {
+if (arrayProto[patchedKey]) {
+  LogManager
+    .getLogger('array-observation')
+    .warn('Detected 2nd attempt of patching array from Aurelia binding.'
+      + ' This is probably caused by dependency mismatch between core modules and a 3rd party plugin.'
+      + ' Please see https://github.com/aurelia/cli/pull/906 if you are using webpack.'
+    );
+} else {
   arrayProto[patchedKey] = 1;
   arrayProto.pop = function() {
     let notEmpty = this.length > 0;

--- a/src/array-observation.js
+++ b/src/array-observation.js
@@ -1,109 +1,115 @@
 /* eslint-disable no-extend-native */
 import {ModifyCollectionObserver} from './collection-observation';
 
-let pop = Array.prototype.pop;
-let push = Array.prototype.push;
-let reverse = Array.prototype.reverse;
-let shift = Array.prototype.shift;
-let sort = Array.prototype.sort;
-let splice = Array.prototype.splice;
-let unshift = Array.prototype.unshift;
+const arrayProto = Array.prototype;
+const pop = arrayProto.pop;
+const push = arrayProto.push;
+const reverse = arrayProto.reverse;
+const shift = arrayProto.shift;
+const sort = arrayProto.sort;
+const splice = arrayProto.splice;
+const unshift = arrayProto.unshift;
+const arrayObserverKey = '__array_observer__';
+const patchedKey = '__au_patched__';
 
-Array.prototype.pop = function() {
-  let notEmpty = this.length > 0;
-  let methodCallResult = pop.apply(this, arguments);
-  if (notEmpty && this.__array_observer__ !== undefined) {
-    this.__array_observer__.addChangeRecord({
-      type: 'delete',
-      object: this,
-      name: this.length,
-      oldValue: methodCallResult
-    });
-  }
-  return methodCallResult;
-};
+if (!arrayProto[patchedKey]) {
+  arrayProto[patchedKey] = 1;
+  arrayProto.pop = function() {
+    let notEmpty = this.length > 0;
+    let methodCallResult = pop.apply(this, arguments);
+    if (notEmpty && this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].addChangeRecord({
+        type: 'delete',
+        object: this,
+        name: this.length,
+        oldValue: methodCallResult
+      });
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.push = function() {
-  let methodCallResult = push.apply(this, arguments);
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.addChangeRecord({
-      type: 'splice',
-      object: this,
-      index: this.length - arguments.length,
-      removed: [],
-      addedCount: arguments.length
-    });
-  }
-  return methodCallResult;
-};
+  arrayProto.push = function() {
+    let methodCallResult = push.apply(this, arguments);
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].addChangeRecord({
+        type: 'splice',
+        object: this,
+        index: this.length - arguments.length,
+        removed: [],
+        addedCount: arguments.length
+      });
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.reverse = function() {
-  let oldArray;
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.flushChangeRecords();
-    oldArray = this.slice();
-  }
-  let methodCallResult = reverse.apply(this, arguments);
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.reset(oldArray);
-  }
-  return methodCallResult;
-};
+  arrayProto.reverse = function() {
+    let oldArray;
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].flushChangeRecords();
+      oldArray = this.slice();
+    }
+    let methodCallResult = reverse.apply(this, arguments);
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].reset(oldArray);
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.shift = function() {
-  let notEmpty = this.length > 0;
-  let methodCallResult = shift.apply(this, arguments);
-  if (notEmpty && this.__array_observer__ !== undefined) {
-    this.__array_observer__.addChangeRecord({
-      type: 'delete',
-      object: this,
-      name: 0,
-      oldValue: methodCallResult
-    });
-  }
-  return methodCallResult;
-};
+  arrayProto.shift = function() {
+    let notEmpty = this.length > 0;
+    let methodCallResult = shift.apply(this, arguments);
+    if (notEmpty && this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].addChangeRecord({
+        type: 'delete',
+        object: this,
+        name: 0,
+        oldValue: methodCallResult
+      });
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.sort = function() {
-  let oldArray;
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.flushChangeRecords();
-    oldArray = this.slice();
-  }
-  let methodCallResult = sort.apply(this, arguments);
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.reset(oldArray);
-  }
-  return methodCallResult;
-};
+  arrayProto.sort = function() {
+    let oldArray;
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].flushChangeRecords();
+      oldArray = this.slice();
+    }
+    let methodCallResult = sort.apply(this, arguments);
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].reset(oldArray);
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.splice = function() {
-  let methodCallResult = splice.apply(this, arguments);
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.addChangeRecord({
-      type: 'splice',
-      object: this,
-      index: +arguments[0],
-      removed: methodCallResult,
-      addedCount: arguments.length > 2 ? arguments.length - 2 : 0
-    });
-  }
-  return methodCallResult;
-};
+  arrayProto.splice = function() {
+    let methodCallResult = splice.apply(this, arguments);
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].addChangeRecord({
+        type: 'splice',
+        object: this,
+        index: +arguments[0],
+        removed: methodCallResult,
+        addedCount: arguments.length > 2 ? arguments.length - 2 : 0
+      });
+    }
+    return methodCallResult;
+  };
 
-Array.prototype.unshift = function() {
-  let methodCallResult = unshift.apply(this, arguments);
-  if (this.__array_observer__ !== undefined) {
-    this.__array_observer__.addChangeRecord({
-      type: 'splice',
-      object: this,
-      index: 0,
-      removed: [],
-      addedCount: arguments.length
-    });
-  }
-  return methodCallResult;
-};
+  arrayProto.unshift = function() {
+    let methodCallResult = unshift.apply(this, arguments);
+    if (this[arrayObserverKey] !== undefined) {
+      this[arrayObserverKey].addChangeRecord({
+        type: 'splice',
+        object: this,
+        index: 0,
+        removed: [],
+        addedCount: arguments.length
+      });
+    }
+    return methodCallResult;
+  };
+}
 
 export function getArrayObserver(taskQueue, array) {
   return ModifyArrayObserver.for(taskQueue, array);
@@ -121,13 +127,13 @@ class ModifyArrayObserver extends ModifyCollectionObserver {
    * @returns ModifyArrayObserver always the same instance for any given array instance
    */
   static for(taskQueue, array) {
-    if (!('__array_observer__' in array)) {
-      Reflect.defineProperty(array, '__array_observer__', {
+    if (!(arrayObserverKey in array)) {
+      Reflect.defineProperty(array, arrayObserverKey, {
         value: ModifyArrayObserver.create(taskQueue, array),
         enumerable: false, configurable: false
       });
     }
-    return array.__array_observer__;
+    return array[arrayObserverKey];
   }
 
   static create(taskQueue, array) {


### PR DESCRIPTION
Things may still go horribly wrong if one ended up having two versions of `aurelia-binding` in the final bundle, but at least array patching won't happen twice. Also trim some unnecessary fat out

Edit: this will work as long as there is no difference between v1 and v2 `ModifyArrayObserver` / `ModifyCollectionObserver`

@EisenbergEffect Should we also replace global `karma start` with npm script ?

resolves #699