### PR TITLE
feat(typings) add missing constructor typing for DataAttributeObserver

### DIFF
--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -415,6 +415,12 @@ export declare class SelectValueObserver implements InternalPropertyObserver {
  * Property observer for HTML Attributes.
  */
 export declare class DataAttributeObserver implements InternalPropertyObserver {
+
+  constructor(
+    element: Element,
+    propertyName: string
+  );
+  
   /**
    * Gets the property value.
    */


### PR DESCRIPTION
Fixes #692