### PR TITLE
Reduce node_modules directory size

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 jspm_packages
 bower_components
 .idea
+build/reports


### PR DESCRIPTION
Apparently I am having some modules that require a different version of some aurelia modules and these reports folders are over 1MB each. There might be even more to gain in this area.

EDIT: Let me know which directories/files can also be added to this list and I will update this PR. Noticed also other Aurelia repo's can have this directory. Let me know if you need me to submit a PR there too.