### PR TITLE
Update Collection Observer Typings

### DIFF
--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -187,8 +187,10 @@ export declare interface ICollectionObserverSplice<T = any, K = any> {
    * The type of change that has taken place. Valid options are "add", "delete", and "update".
    * 
    * *Note:* "update" is invalid for Set.
+   * 
+   * *Note:* "clear" is only valid for Map and Set.
    */
-  type: "add" | "delete" | "update";
+  type: "add" | "delete" | "update" | "clear";
 }
 
 /**

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -184,7 +184,7 @@ export declare interface ICollectionObserverSplice<T = any, K = any> {
   value: T;
                                                    
   /**
-   * The type of change that has taken place. Valid options are "add", "delete", and "update".
+   * The type of change that has taken place. Valid options are "add", "delete", "update", and  "clear".
    * 
    * *Note:* "update" is invalid for Set.
    * 

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -184,10 +184,13 @@ export declare interface ICollectionObserverSplice<T = any, K = any> {
   value: T;
                                                    
   /**
-   * The type of change that has taken place. Valid options are "add", "delete", and "update".
-   * "update" is invalid for Set.
+   * The type of change that has taken place. Valid options are "splice", "add", "delete", "update", and "clear".
+   * 
+   * *Note:* "splice" is only valid for Array; "add", "update", and "clear" are invalid for Array.
+   * 
+   * *Note:* "update" is invalid for Set.
    */
-  type: "add" | "delete" | "update";
+  type: "splice" | "add" | "delete" | "update" | "clear";
 }
 
 /**
@@ -509,6 +512,28 @@ export declare interface InternalCollectionObserver {
    * @param callable A callable object.
    */
   unsubscribe(context: any, callable: Callable): void;
+  /**
+   * Adds a change record to the collection observer.
+   * @param changeRecord 
+   */
+  addChangeRecord(changeRecord: ICollectionObserverSplice): void;
+  /**
+   * This will flush the change records of this observer and call any subscribers if applicable.
+   */
+  flushChangeRecords(): void;
+  /**
+   * Reset the observer to the passed collection and call any subscribers with changes between the current collection and the reset collection.
+   * @param oldCollection 
+   */
+  reset(oldCollection): void;
+  /**
+   * Get a length observer for this collection.
+   */
+  getLengthObserver(): any;
+  /**
+   * This will call subscribers notifying of changed records.
+   */
+  call(): void;
 }
 
 /**
@@ -821,6 +846,10 @@ export declare class ObserverLocator {
    * Gets an observer for map mutation.
    */
   getMapObserver(map: Map<any, any>): InternalCollectionObserver;
+  /**
+   * Gets an observer for set mutation.
+   */
+  getSetObserver(set: Set<any>): InternalCollectionObserver;
 }
 
 /**

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -145,7 +145,7 @@ export declare interface CollectionObserver {
 /**
  * The change record of a collection mutation. 
  */
-export declare interface ICollectionObserverSplice<T = any> {
+export declare interface ICollectionObserverSplice<T = any, K = any> {
   /* ArrayObserverSplice */
   /**
    * Number of items added to the collection.
@@ -166,12 +166,12 @@ export declare interface ICollectionObserverSplice<T = any> {
   /**
    * The observed Set or Map after the change.
    */
-  object: Set<T> | Map<K, V>;
+  object: Set<T> | Map<K, T>;
                                                    
   /**
    * The value of the Map item prior to the change.
    */
-  oldValue: V;
+  oldValue: T;
        
   /**
    * The key of the Map item that was changed.

--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -184,13 +184,11 @@ export declare interface ICollectionObserverSplice<T = any, K = any> {
   value: T;
                                                    
   /**
-   * The type of change that has taken place. Valid options are "splice", "add", "delete", "update", and "clear".
-   * 
-   * *Note:* "splice" is only valid for Array; "add", "update", and "clear" are invalid for Array.
+   * The type of change that has taken place. Valid options are "add", "delete", and "update".
    * 
    * *Note:* "update" is invalid for Set.
    */
-  type: "splice" | "add" | "delete" | "update" | "clear";
+  type: "add" | "delete" | "update";
 }
 
 /**
@@ -513,11 +511,6 @@ export declare interface InternalCollectionObserver {
    */
   unsubscribe(context: any, callable: Callable): void;
   /**
-   * Adds a change record to the collection observer.
-   * @param changeRecord 
-   */
-  addChangeRecord(changeRecord: ICollectionObserverSplice): void;
-  /**
    * This will flush the change records of this observer and call any subscribers if applicable.
    */
   flushChangeRecords(): void;
@@ -525,15 +518,11 @@ export declare interface InternalCollectionObserver {
    * Reset the observer to the passed collection and call any subscribers with changes between the current collection and the reset collection.
    * @param oldCollection 
    */
-  reset(oldCollection): void;
+  reset(oldCollection: any[] | Set<any> | Map<any, any>): void;
   /**
    * Get a length observer for this collection.
    */
   getLengthObserver(): any;
-  /**
-   * This will call subscribers notifying of changed records.
-   */
-  call(): void;
 }
 
 /**


### PR DESCRIPTION
Correction to the ICollectionObserverSplice interface. Adding missing methods to the InternalCollectionObserver interface and ObserverLocator class.

One thing I noticed with the InternalCollectionObserver interface was the `subscribe(callback: (changeRecords: any) => void): void;` and `unsubscribe(callback: (changeRecords: any) => void): void;` method definitions; am I crazy to think that these are not supported / depreciated?