### PR TITLE
fix(name-binding): add extra props to update one time mode

### DIFF
--- a/src/name-expression.js
+++ b/src/name-expression.js
@@ -74,6 +74,9 @@ class NameBinder {
   }
 
   call() {
+    if (!this.isBound) {
+      return;
+    }
     this.sourceExpression.assign(this.source, this.target, this.lookupFunctions);
   }
 

--- a/src/name-expression.js
+++ b/src/name-expression.js
@@ -1,3 +1,5 @@
+import { bindingMode } from './binding-mode';
+
 function getAU(element) {
   let au = element.au;
 
@@ -43,10 +45,17 @@ export class NameExpression {
 }
 
 class NameBinder {
+  /**
+   * Name binding for reference
+   * @param {Expression} sourceExpression
+   * @param {any} target
+   * @param {any} lookupFunctions
+   */
   constructor(sourceExpression, target, lookupFunctions) {
     this.sourceExpression = sourceExpression;
     this.target = target;
     this.lookupFunctions = lookupFunctions;
+    this.mode = bindingMode.oneTime;
   }
 
   bind(source) {
@@ -64,16 +73,21 @@ class NameBinder {
     this.sourceExpression.assign(this.source, this.target, this.lookupFunctions);
   }
 
+  call() {
+    this.sourceExpression.assign(this.source, this.target, this.lookupFunctions);
+  }
+
   unbind() {
     if (!this.isBound) {
       return;
     }
     this.isBound = false;
-    if (this.sourceExpression.evaluate(this.source, this.lookupFunctions) === this.target) {
-      this.sourceExpression.assign(this.source, null, this.lookupFunctions);
+    const { source, lookupFunctions, sourceExpression } = this;
+    if (sourceExpression.evaluate(source, lookupFunctions) === this.target) {
+      sourceExpression.assign(source, null, lookupFunctions);
     }
-    if (this.sourceExpression.unbind) {
-      this.sourceExpression.unbind(this, this.source);
+    if (sourceExpression.unbind) {
+      sourceExpression.unbind(this, source);
     }
     this.source = null;
   }

--- a/test/name-expression.spec.js
+++ b/test/name-expression.spec.js
@@ -8,6 +8,7 @@ import {
 } from '../src/ast';
 import {createScopeForTest} from '../src/scope';
 import {NameExpression} from '../src/name-expression';
+import { bindingMode } from '../src/binding-mode';
 
 describe('NameExpression', () => {
   let element;
@@ -21,6 +22,13 @@ describe('NameExpression', () => {
         }
       }
     };
+  });
+
+  it('creates one time binding mode binding', () => {
+    let sourceExpression = new AccessScope('foo');
+    let expression = new NameExpression(sourceExpression, 'element');
+    let binding = expression.createBinding(element);
+    expect(binding.mode).toBe(bindingMode.oneTime);
   });
 
   it('binds element to scope', () => {
@@ -103,5 +111,18 @@ describe('NameExpression', () => {
     scope.bindingContext.foo = 'should remain';
     binding.unbind();
     expect(scope.bindingContext.foo).toBe('should remain');
+  });
+
+  it('re-assigns value when invoking call()', () => {
+    let sourceExpression = new AccessScope('foo');
+    let expression = new NameExpression(sourceExpression, 'element');
+    let scope = createScopeForTest({});
+    let binding = expression.createBinding(element);
+    binding.bind(scope);
+    expect(scope.bindingContext.foo).toBe(element);
+    scope.bindingContext.foo = null;
+    expect(binding.target).toBe(element);
+    binding.call();
+    expect(scope.bindingContext.foo).toBe(element);
   });
 });

--- a/test/name-expression.spec.js
+++ b/test/name-expression.spec.js
@@ -125,4 +125,21 @@ describe('NameExpression', () => {
     binding.call();
     expect(scope.bindingContext.foo).toBe(element);
   });
+
+  it('does nothing when not bound + invoking call()', () => {
+    let sourceExpression = new AccessScope('foo');
+    let expression = new NameExpression(sourceExpression, 'element');
+    let scope = createScopeForTest({});
+    let binding = expression.createBinding(element);
+    binding.bind(scope);
+    expect(scope.bindingContext.foo).toBe(element);
+    scope.bindingContext.foo = null;
+    expect(binding.target).toBe(element);
+    binding.isBound = false;
+    binding.call();
+    expect(scope.bindingContext.foo).toBe(null);
+    binding.isBound = true;
+    binding.call();
+    expect(scope.bindingContext.foo).toBe(element);
+  });
 });


### PR DESCRIPTION
Thanks to `@edwrd01` on Discourse at https://discourse.aurelia.io/t/issue-using-ref-in-a-repeat-for-with-a-value-converter/2328/5 , we uncover an issue related the combination of `ref` binding, `repeat` and `value-converter/binding-behavior`. The issue is due to `repeat` custom attribute unable to update ref binding, in case of a mutation in source collection, piped through value converter / binding behavior. i.e:

```html
  <div repeat.for="item of items | vc & bb">
```

As it uses this https://github.com/aurelia/templating-resources/blob/0896552d553af0d69399b9b227317a26bdc14005/src/repeat-utilities.js#L109-L115 under the hood to update the bindings that do not employ observation, `NameBinder` is one of those binding types. There are two ways to fix it:

1. add method `updateOneTimeBindings` to reassign target
2. add binding mode `oneTime`, and add method `call` to reassign target

I went with (2) since it seems to align better with other bindings, also the location of this class (binding module).

cc @EisenbergEffect @fkleuver 
