### PR TITLE
fix(connectable-binding): remove the silent limit of 100 observers per expression

### DIFF
--- a/src/connectable-binding.js
+++ b/src/connectable-binding.js
@@ -1,12 +1,20 @@
 import {sourceContext} from './call-context';
 
+
 const slotNames = [];
 const versionSlotNames = [];
-
-for (let i = 0; i < 100; i++) {
-  slotNames.push(`_observer${i}`);
-  versionSlotNames.push(`_observerVersion${i}`);
+let lastSlot = -1;
+function ensureEnoughSlotNames(currentSlot) {
+  if (currentSlot === lastSlot) {
+    lastSlot += 5;
+    const ii = slotNames.length = versionSlotNames.length = lastSlot + 1;
+    for (let i = currentSlot + 1; i < ii; ++i) {
+      slotNames[i] = `_observer${i}`;
+      versionSlotNames[i] = `_observerVersion${i}`;
+    }
+  }
 }
+ensureEnoughSlotNames(-1);
 
 function addObserver(observer) {
   // find the observer.
@@ -34,6 +42,7 @@ function addObserver(observer) {
     this._version = 0;
   }
   this[versionSlotNames[i]] = this._version;
+  ensureEnoughSlotNames(i);
 }
 
 function observeProperty(obj, propertyName) {


### PR DESCRIPTION
This is directly ported from [vNext](https://github.com/aurelia/aurelia/blob/master/packages/runtime/src/binding/connectable.ts#L15)

fixes #742