### PR TITLE
fix(build): run build-dts after all others

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -107,8 +107,8 @@ gulp.task('build', function(callback) {
     'clean',
     'build-index',
     compileToModules
-      .map(function(moduleType) { return 'build-babel-' + moduleType })
-      .concat(['build-dts']),
+      .map(function(moduleType) { return 'build-babel-' + moduleType }),
+    'build-dts',
     callback
   );
 });


### PR DESCRIPTION
In my previous attempt at #740, `declaration` in `tsconfig` was changed to false to make build not override type definition file in dist. But proper fix is to run `build-dts` task after all other tasks, so it would always make sure we have right type definitions in distribution

@EisenbergEffect @fkleuver 