### PR TITLE
fix(typing): Make parentOverrideContext optional

### DIFF
--- a/src/aurelia-binding.d.ts
+++ b/src/aurelia-binding.d.ts
@@ -6,7 +6,7 @@ import { Container } from 'aurelia-dependency-injection';
  * object take precedence over members of the bindingContext object.
  */
 export declare interface OverrideContext {
-  parentOverrideContext: OverrideContext;
+  parentOverrideContext?: OverrideContext;
   bindingContext: any;
 }
 


### PR DESCRIPTION
Make property optional to prevent infinite loop in typing.

Closes #756