### PR TITLE
don't allow call binding to affect the overrideContext

### DIFF
--- a/src/call-expression.js
+++ b/src/call-expression.js
@@ -26,15 +26,10 @@ export class Call {
   }
 
   callSource($event) {
-    let overrideContext = this.source.overrideContext;
-    Object.assign(overrideContext, $event);
+    let overrideContext = Object.assign({}, this.source.overrideContext, $event);
     overrideContext.$event = $event; // deprecate this?
     let mustEvaluate = true;
-    let result = this.sourceExpression.evaluate(this.source, this.lookupFunctions, mustEvaluate);
-    delete overrideContext.$event;
-    for (let prop in $event) {
-      delete overrideContext[prop];
-    }
+    let result = this.sourceExpression.evaluate(Object.assign({}, this.source, {overrideContext: overrideContext}), this.lookupFunctions, mustEvaluate);
     return result;
   }
 

--- a/test/call-expression.spec.js
+++ b/test/call-expression.spec.js
@@ -1,16 +1,11 @@
 import './setup';
-import {
-  createElement,
-  checkDelay,
-  createObserverLocator,
-  getBinding
-} from './shared';
+import {createObserverLocator} from './shared';
 import {Parser} from '../src/parser';
 import {CallExpression} from '../src/call-expression';
 import {createScopeForTest} from '../src/scope';
 
 describe('CallExpression', () => {
-  let expression, viewModel, target = {}, binding;
+  let expression, viewModel, target = {}, binding, scope;
 
   beforeAll(() => {
     viewModel = {
@@ -32,7 +27,8 @@ describe('CallExpression', () => {
   it('binds', () => {
     expect(target.foo).toBeUndefined();
     binding = expression.createBinding(target);
-    binding.bind(createScopeForTest(viewModel));
+    scope = createScopeForTest(viewModel);
+    binding.bind(scope);
     expect(target.foo).toBeDefined();
   });
 
@@ -61,6 +57,13 @@ describe('CallExpression', () => {
     let result = target.foo();
     expect(result).toBe(viewModel.arg1);
     expect(viewModel.doSomething).toHaveBeenCalledWith(undefined, viewModel.arg1, viewModel.arg2);
+  });
+
+  it('shouldn\'t affect the overrideContext', () => {
+    let args = { arg1: 'hello' };
+    scope.overrideContext.arg1 = 'bar';
+    target.foo(args);
+    expect(scope.overrideContext.arg1).toBe('bar');
   });
 
   it('unbinds', () => {


### PR DESCRIPTION
We ran into an issue where in case of a naming collision in the call args with properties on the overrideContext, those properties would disappear from the overrideContext. This makes sure that doesn't happen.