### PR TITLE
fix: AccessMember.evaluate should always return undefined for non-existing members #795

### DIFF
--- a/dist/amd/aurelia-binding.js
+++ b/dist/amd/aurelia-binding.js
@@ -1504,7 +1504,7 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aure
 
     AccessMember.prototype.evaluate = function evaluate(scope, lookupFunctions) {
       var instance = this.object.evaluate(scope, lookupFunctions);
-      return instance === null || instance === undefined ? instance : instance[this.name];
+      return instance === null || instance === undefined ? undefined : instance[this.name];
     };
 
     AccessMember.prototype.assign = function assign(scope, value) {

--- a/dist/aurelia-binding.js
+++ b/dist/aurelia-binding.js
@@ -1440,7 +1440,7 @@ export class AccessMember extends Expression {
 
   evaluate(scope, lookupFunctions) {
     let instance = this.object.evaluate(scope, lookupFunctions);
-    return instance === null || instance === undefined ? instance : instance[this.name];
+    return instance === null || instance === undefined ? undefined : instance[this.name];
   }
 
   assign(scope, value) {

--- a/dist/commonjs/aurelia-binding.js
+++ b/dist/commonjs/aurelia-binding.js
@@ -1457,7 +1457,7 @@ var AccessMember = exports.AccessMember = function (_Expression7) {
 
   AccessMember.prototype.evaluate = function evaluate(scope, lookupFunctions) {
     var instance = this.object.evaluate(scope, lookupFunctions);
-    return instance === null || instance === undefined ? instance : instance[this.name];
+    return instance === null || instance === undefined ? undefined : instance[this.name];
   };
 
   AccessMember.prototype.assign = function assign(scope, value) {

--- a/dist/es2015/aurelia-binding.js
+++ b/dist/es2015/aurelia-binding.js
@@ -1332,7 +1332,7 @@ export let AccessMember = class AccessMember extends Expression {
 
   evaluate(scope, lookupFunctions) {
     let instance = this.object.evaluate(scope, lookupFunctions);
-    return instance === null || instance === undefined ? instance : instance[this.name];
+    return instance === null || instance === undefined ? undefined : instance[this.name];
   }
 
   assign(scope, value) {

--- a/dist/native-modules/aurelia-binding.js
+++ b/dist/native-modules/aurelia-binding.js
@@ -1419,7 +1419,7 @@ export var AccessMember = function (_Expression7) {
 
   AccessMember.prototype.evaluate = function evaluate(scope, lookupFunctions) {
     var instance = this.object.evaluate(scope, lookupFunctions);
-    return instance === null || instance === undefined ? instance : instance[this.name];
+    return instance === null || instance === undefined ? undefined : instance[this.name];
   };
 
   AccessMember.prototype.assign = function assign(scope, value) {

--- a/dist/system/aurelia-binding.js
+++ b/dist/system/aurelia-binding.js
@@ -1859,7 +1859,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-task-queue', 'aureli
 
         AccessMember.prototype.evaluate = function evaluate(scope, lookupFunctions) {
           var instance = this.object.evaluate(scope, lookupFunctions);
-          return instance === null || instance === undefined ? instance : instance[this.name];
+          return instance === null || instance === undefined ? undefined : instance[this.name];
         };
 
         AccessMember.prototype.assign = function assign(scope, value) {

--- a/src/ast.js
+++ b/src/ast.js
@@ -250,7 +250,7 @@ export class AccessMember extends Expression {
 
   evaluate(scope, lookupFunctions) {
     let instance = this.object.evaluate(scope, lookupFunctions);
-    return instance === null || instance === undefined ? instance : instance[this.name];
+    return instance === null || instance === undefined ? undefined : instance[this.name];
   }
 
   assign(scope, value) {

--- a/test/ast/access-member.spec.js
+++ b/test/ast/access-member.spec.js
@@ -21,14 +21,14 @@ describe('AccessMember', () => {
 
   it('assigns member on bindingContext', () => {
     let scope = createScopeForTest({ foo: { bar: 'baz' } });
-    expression.assign(scope, 'bang')
+    expression.assign(scope, 'bang');
     expect(scope.bindingContext.foo.bar).toBe('bang');
   });
 
   it('assigns member on overrideContext', () => {
     let scope = createScopeForTest({});
     scope.overrideContext.foo = { bar: 'baz' };
-    expression.assign(scope, 'bang')
+    expression.assign(scope, 'bang');
     expect(scope.overrideContext.foo.bar).toBe('bang');
   });
 
@@ -36,4 +36,20 @@ describe('AccessMember', () => {
     let scope = createScopeForTest({ foo: { bar: 'baz' } });
     expect(expression.assign(scope, 'bang')).toBe('bang');
   });
+
+  it('returns `undefined` for a non-existing member of `null` object', () => {
+    let scope = createScopeForTest({ foo: null });
+    expect(expression.evaluate(scope, null)).toBeUndefined();
+  });
+
+  it('returns `undefined` for a non-existing member of `undefined` object', () => {
+    let scope = createScopeForTest({ foo: undefined });
+    expect(expression.evaluate(scope, null)).toBeUndefined();
+  });
+
+  it('returns `undefined` for a non-existing member of non-existing object', () => {
+    let scope = createScopeForTest({});
+    expect(expression.evaluate(scope, null)).toBeUndefined();
+  });
+
 });


### PR DESCRIPTION
Fix for issue the #795 